### PR TITLE
feat: support Lambda extensions and AWS Lambda Web Adapter locally

### DIFF
--- a/examples/complete/functions/echo/Dockerfile
+++ b/examples/complete/functions/echo/Dockerfile
@@ -1,22 +1,20 @@
-# Node.js-based Lambda container for the echo handler
-# This uses the official Lambda Node.js runtime image
+# Bun-based Lambda container using AWS Lambda Web Adapter
+# This allows the handler to run as a standard HTTP server
 
-FROM oven/bun:1 AS builder
+FROM oven/bun:1-alpine
 
-WORKDIR /build
+# Install Lambda Web Adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
 
-# Copy and install dependencies (if any)
+WORKDIR /app
+
+# Copy the handler
 COPY handler.ts .
 
-# Bundle the handler for Node.js (CJS for Lambda runtime)
-RUN bun build handler.ts --outfile=handler.js --target=node --format=cjs
+# Expose server port for local testing
+EXPOSE 8080
 
-# Production image based on AWS Lambda Node.js runtime
-FROM public.ecr.aws/lambda/nodejs:24-arm64
+# Lambda Web Adapter expects the server to listen on PORT
+ENV PORT=8080
 
-# Copy the bundled handler
-WORKDIR /var/task
-COPY --from=builder /build/handler.js .
-
-# Lambda Node.js runtime reads the handler from CMD
-CMD ["handler.handler"]
+CMD ["bun", "handler.ts"]

--- a/examples/complete/functions/echo/handler.ts
+++ b/examples/complete/functions/echo/handler.ts
@@ -1,46 +1,58 @@
 /**
- * Simple echo handler that returns the input event.
+ * Simple echo handler running as a Bun HTTP server.
  *
- * This handler is used in a Bun-based Docker Lambda to demonstrate
- * the live debugging workflow with DockerImageFunction.
+ * This handler uses AWS Lambda Web Adapter to run as a standard HTTP server
+ * inside Lambda, demonstrating the live debugging workflow with DockerImageFunction.
  */
-
-import type { Context } from "aws-lambda"
 
 interface EchoResponse {
   message: string
   event: unknown
-  context: {
-    functionName: string
-    functionVersion: string
-    awsRequestId: string
-    memoryLimitInMB: string
-  }
+  requestId: string
   timestamp: string
 }
 
-/**
- * Echo handler - returns the event along with context info
- */
-export async function handler(
-  event: unknown,
-  context: Context,
-): Promise<EchoResponse> {
-  console.log("[Echo] Received event:", JSON.stringify(event))
+const PORT = Number(process.env.PORT) || 8080
 
-  const response: EchoResponse = {
-    message: "Hello from the echo handler!",
-    event,
-    context: {
-      functionName: context.functionName,
-      functionVersion: context.functionVersion,
-      awsRequestId: context.awsRequestId,
-      memoryLimitInMB: context.memoryLimitInMB,
-    },
-    timestamp: new Date().toISOString(),
-  }
+const server = Bun.serve({
+  port: PORT,
+  async fetch(request: Request): Promise<Response> {
+    // Lambda Web Adapter sends the event as POST body to the root path
+    // and includes Lambda context in headers
+    const requestId =
+      request.headers.get("x-amzn-request-id") ||
+      request.headers.get("x-request-id") ||
+      crypto.randomUUID()
 
-  console.log("[Echo] Returning response:", JSON.stringify(response))
+    console.log(`[Echo] Received request: ${request.method} ${request.url}`)
 
-  return response
-}
+    let event: unknown = null
+    if (request.method === "POST") {
+      try {
+        event = await request.json()
+      } catch {
+        event = await request.text()
+      }
+    }
+
+    console.log("[Echo] Event:", JSON.stringify(event))
+
+    const response: EchoResponse = {
+      message: "Hello from the echo handler!",
+      event,
+      requestId,
+      timestamp: new Date().toISOString(),
+    }
+
+    console.log("[Echo] Returning response:", JSON.stringify(response))
+
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+  },
+})
+
+console.log(`[Echo] Server listening on port ${server.port}`)

--- a/src/cli/commands/local.ts
+++ b/src/cli/commands/local.ts
@@ -52,6 +52,7 @@ import {
 } from "../../shared/types.js"
 import { makeAppSyncClient } from "../appsync/client.js"
 import {
+  buildExtensionWrapperCommand,
   Docker,
   DockerLive,
   makeLambdaContainerConfig,
@@ -61,6 +62,7 @@ import {
   watchDockerContexts,
 } from "../docker/watcher.js"
 import {
+  notifyExtensionsInvoke,
   queueInvocation,
   type RuntimeApiState,
   startRuntimeApiServer,
@@ -421,6 +423,13 @@ const startFunctionContainer = (
       })
       .pipe(Effect.scoped)
 
+    // Inspect the image to get original entrypoint/cmd for extension wrapper
+    const imageConfig = yield* docker.inspect(imageName).pipe(Effect.scoped)
+    const extensionWrapper = buildExtensionWrapperCommand(
+      imageConfig.entrypoint,
+      imageConfig.cmd,
+    )
+
     const containerConfig = makeLambdaContainerConfig({
       imageUri: imageName,
       runtimeApiHost,
@@ -433,6 +442,10 @@ const startFunctionContainer = (
       additionalEnv,
       invocationContexts,
     })
+
+    // Apply extension wrapper to start extensions before the app
+    containerConfig.entrypoint = extensionWrapper.entrypoint
+    containerConfig.command = extensionWrapper.command
 
     yield* Effect.logInfo(
       `Starting container for ${fn.functionName} on port ${port}`,
@@ -880,9 +893,13 @@ const ensureWorkerStarted = (
     )
 
     // Create Runtime API server on ephemeral port
-    const { port, state: runtimeState } = yield* startRuntimeApiServer().pipe(
-      Effect.provideService(Scope.Scope, serverScope),
-    )
+    const { port, state: runtimeState } = yield* startRuntimeApiServer({
+      functionMetadata: {
+        functionName: fn.functionName,
+        functionVersion: "$LATEST",
+        handler: fn.localHandler,
+      },
+    }).pipe(Effect.provideService(Scope.Scope, serverScope))
 
     // Create worker object (without process initially - will be set after start)
     // We add to map BEFORE starting worker to handle concurrent invocations
@@ -1032,9 +1049,14 @@ const ensureContainerStarted = (
 
     // Create Runtime API server on ephemeral port
     // Use poll timeout that's shorter than idle timeout so container exits naturally
-    const { port, state: runtimeState } = yield* startRuntimeApiServer(
+    const { port, state: runtimeState } = yield* startRuntimeApiServer({
       pollTimeoutMs,
-    ).pipe(Effect.provideService(Scope.Scope, serverScope))
+      functionMetadata: {
+        functionName: fn.functionName,
+        functionVersion: "$LATEST",
+        handler: "index.handler",
+      },
+    }).pipe(Effect.provideService(Scope.Scope, serverScope))
 
     // Generate container name and image name
     const containerName = `lambda-${fn.functionName.replace(/[^a-zA-Z0-9]/g, "-")}`
@@ -1158,6 +1180,15 @@ const rebuildDockerContainer = (
       })
       .pipe(Effect.scoped)
 
+    // Inspect the image to get original entrypoint/cmd for extension wrapper
+    const imageConfig = yield* docker
+      .inspect(container.imageName)
+      .pipe(Effect.scoped)
+    const extensionWrapper = buildExtensionWrapperCommand(
+      imageConfig.entrypoint,
+      imageConfig.cmd,
+    )
+
     // Restart the container by triggering container startup
     // The existing fiber will have exited when we stopped the container
     // We need to start a new one
@@ -1180,6 +1211,10 @@ const rebuildDockerContainer = (
       timeoutSeconds: 3600,
       platform,
     })
+
+    // Apply extension wrapper to start extensions before the app
+    containerConfig.entrypoint = extensionWrapper.entrypoint
+    containerConfig.command = extensionWrapper.command
 
     // Start the new container
     yield* Effect.logDebug(
@@ -1295,6 +1330,8 @@ const handleDockerInvocation = (
     yield* Effect.logDebug(
       `[Local] Queueing to Runtime API on port ${container.port}`,
     )
+    // Notify extensions about the invocation (for Lambda Web Adapter support)
+    yield* notifyExtensionsInvoke(container.runtimeState, lambdaInvocation)
     yield* queueInvocation(container.runtimeState, lambdaInvocation)
     yield* Effect.logDebug(`[Local] Invocation queued successfully`)
   })

--- a/src/cli/docker/container.ts
+++ b/src/cli/docker/container.ts
@@ -7,13 +7,11 @@
  */
 
 import * as os from "node:os"
-import {
-  type CommandExecutor,
-  Command as PlatformCommand,
-} from "@effect/platform"
+import { CommandExecutor, Command as PlatformCommand } from "@effect/platform"
 import type { Process as EffectProcess } from "@effect/platform/CommandExecutor"
 import { Context, Effect, Layer, type Scope, Stream } from "effect"
 import type {
+  DockerImageConfig,
   DockerRunConfig,
   DockerRunResult,
   DockerRuntimeInfo,
@@ -114,8 +112,23 @@ const buildDockerRunArgs = (
     args.push(...config.additionalArgs)
   }
 
+  // Entrypoint override
+  if (config.entrypoint && config.entrypoint.length > 0) {
+    args.push("--entrypoint", config.entrypoint[0])
+  }
+
   // Image
   args.push(config.imageUri)
+
+  // Entrypoint additional args (after image)
+  if (config.entrypoint && config.entrypoint.length > 1) {
+    args.push(...config.entrypoint.slice(1))
+  }
+
+  // Command override (after image and entrypoint args)
+  if (config.command) {
+    args.push(...config.command)
+  }
 
   return args
 }
@@ -199,6 +212,18 @@ export interface DockerService {
    * Get the detected Docker runtime info.
    */
   readonly getRuntimeInfo: () => Effect.Effect<DockerRuntimeInfo, Error>
+
+  /**
+   * Inspect a Docker image to get its configuration.
+   * Returns the ENTRYPOINT and CMD from the image.
+   */
+  readonly inspect: (
+    imageUri: string,
+  ) => Effect.Effect<
+    DockerImageConfig,
+    Error,
+    Scope.Scope | CommandExecutor.CommandExecutor
+  >
 }
 
 /**
@@ -545,6 +570,67 @@ const makeDockerService: Effect.Effect<DockerService, Error> = Effect.gen(
         return containerIds.length
       })
 
+    const inspect: DockerService["inspect"] = (imageUri) =>
+      Effect.gen(function* () {
+        const executor = yield* CommandExecutor.CommandExecutor
+
+        // Get entrypoint
+        const entrypointCmd = PlatformCommand.make(
+          runtime.dockerPath,
+          "inspect",
+          "--format",
+          "{{json .Config.Entrypoint}}",
+          imageUri,
+        )
+        const entrypointProc = yield* executor.start(entrypointCmd)
+        const entrypointOutput = yield* Stream.runCollect(
+          Stream.decodeText(entrypointProc.stdout),
+        )
+        const entrypointExitCode = yield* entrypointProc.exitCode
+        if (entrypointExitCode !== 0) {
+          yield* Effect.fail(
+            new Error(`Failed to inspect image entrypoint: ${imageUri}`),
+          )
+        }
+        const entrypointJson = Array.from(entrypointOutput).join("").trim()
+
+        // Get cmd
+        const cmdCmd = PlatformCommand.make(
+          runtime.dockerPath,
+          "inspect",
+          "--format",
+          "{{json .Config.Cmd}}",
+          imageUri,
+        )
+        const cmdProc = yield* executor.start(cmdCmd)
+        const cmdOutput = yield* Stream.runCollect(
+          Stream.decodeText(cmdProc.stdout),
+        )
+        const cmdExitCode = yield* cmdProc.exitCode
+        if (cmdExitCode !== 0) {
+          yield* Effect.fail(
+            new Error(`Failed to inspect image cmd: ${imageUri}`),
+          )
+        }
+        const cmdJson = Array.from(cmdOutput).join("").trim()
+
+        // Parse JSON - null is valid, so handle that
+        const parseJsonArray = (json: string): string[] | null => {
+          if (json === "null" || json === "") return null
+          try {
+            const parsed = JSON.parse(json)
+            return Array.isArray(parsed) ? parsed : null
+          } catch {
+            return null
+          }
+        }
+
+        return {
+          entrypoint: parseJsonArray(entrypointJson),
+          cmd: parseJsonArray(cmdJson),
+        }
+      })
+
     return {
       run,
       runScoped,
@@ -553,6 +639,7 @@ const makeDockerService: Effect.Effect<DockerService, Error> = Effect.gen(
       stop,
       list,
       getRuntimeInfo,
+      inspect,
     } satisfies DockerService
   },
 )
@@ -611,4 +698,56 @@ export const makeLambdaContainerConfig = (options: {
 export interface ContainerOutput {
   type: "stdout" | "stderr"
   data: string
+}
+
+/**
+ * Shell-quote a string for safe inclusion in a shell command.
+ * Uses single quotes and escapes any embedded single quotes.
+ */
+const shellQuote = (s: string): string => {
+  // Single quotes are safest - escape any embedded single quotes
+  return `'${s.replace(/'/g, "'\\''")}'`
+}
+
+/**
+ * Build a wrapper command that starts Lambda extensions before the main app.
+ *
+ * This mimics AWS Lambda's behavior of automatically starting all executables
+ * in /opt/extensions/ as background processes before running the main command.
+ *
+ * @param originalEntrypoint - The image's original ENTRYPOINT
+ * @param originalCmd - The image's original CMD
+ * @returns Entrypoint and command arrays to pass to Docker
+ */
+export const buildExtensionWrapperCommand = (
+  originalEntrypoint: string[] | null,
+  originalCmd: string[] | null,
+): { entrypoint: string[]; command: string[] } => {
+  // Combine original entrypoint + cmd into the full command
+  // Docker behavior: ENTRYPOINT + CMD are concatenated
+  const originalCommand = [
+    ...(originalEntrypoint ?? []),
+    ...(originalCmd ?? []),
+  ]
+
+  // Script to start all executable files in /opt/extensions/ as background processes
+  const extensionStarter =
+    'for ext in /opt/extensions/*; do [ -x "$ext" ] && "$ext" & done'
+
+  // Build the full wrapper command
+  let fullCommand: string
+  if (originalCommand.length > 0) {
+    // Quote each argument and join with spaces
+    const quotedOriginal = originalCommand.map(shellQuote).join(" ")
+    // Start extensions, then exec the original command
+    fullCommand = `${extensionStarter}; exec ${quotedOriginal}`
+  } else {
+    // No original command - just start extensions (unusual but handle it)
+    fullCommand = extensionStarter
+  }
+
+  return {
+    entrypoint: ["/bin/sh"],
+    command: ["-c", fullCommand],
+  }
 }

--- a/src/cli/docker/types.ts
+++ b/src/cli/docker/types.ts
@@ -28,6 +28,20 @@ export interface DockerRunConfig {
   additionalArgs?: string[]
   /** Optional invocation context map for log prefixing (requestId -> { num }) */
   invocationContexts?: Map<string, { num: number }>
+  /** Override the container's entrypoint */
+  entrypoint?: string[]
+  /** Override the container's command (arguments after the image) */
+  command?: string[]
+}
+
+/**
+ * Docker image configuration from inspection.
+ */
+export interface DockerImageConfig {
+  /** The image's ENTRYPOINT */
+  entrypoint: string[] | null
+  /** The image's CMD */
+  cmd: string[] | null
 }
 
 /**

--- a/src/cli/runtime-api/server.ts
+++ b/src/cli/runtime-api/server.ts
@@ -16,13 +16,35 @@ import * as HttpRouter from "@effect/platform/HttpRouter"
 import * as HttpServerRequest from "@effect/platform/HttpServerRequest"
 import * as HttpServerResponse from "@effect/platform/HttpServerResponse"
 import * as BunHttpServer from "@effect/platform-bun/BunHttpServer"
-import { Effect, Option, Queue, type Scope } from "effect"
+import { Effect, HashMap, Option, Queue, Ref, type Scope } from "effect"
 import type {
+  ExtensionEvent,
+  ExtensionEventType,
   LambdaError,
   LambdaInitError,
   LambdaInvocation,
   LambdaResponse,
+  RegisteredExtension,
 } from "./types.js"
+
+/**
+ * State for a registered extension.
+ */
+interface ExtensionState {
+  /** Extension info */
+  extension: RegisteredExtension
+  /** Queue of events for this extension */
+  eventQueue: Queue.Queue<ExtensionEvent>
+}
+
+/**
+ * Function metadata for extension registration responses.
+ */
+export interface FunctionMetadata {
+  functionName: string
+  functionVersion: string
+  handler: string
+}
 
 /**
  * State for a Runtime API server session.
@@ -33,6 +55,10 @@ export interface RuntimeApiState {
   invocationQueue: Queue.Queue<LambdaInvocation>
   /** Queue for responses/errors from the container */
   responseQueue: Queue.Queue<LambdaResponse | LambdaError | LambdaInitError>
+  /** Registered extensions by extension ID */
+  extensions: Ref.Ref<HashMap.HashMap<string, ExtensionState>>
+  /** Function metadata for extension registration */
+  functionMetadata: FunctionMetadata
 }
 
 /**
@@ -47,17 +73,22 @@ export interface RuntimeApiServer {
 
 /**
  * Create a new Runtime API state (queues only, no port).
+ *
+ * @param functionMetadata - Function metadata for extension registration responses
  */
-export const makeRuntimeApiState = () =>
+export const makeRuntimeApiState = (functionMetadata: FunctionMetadata) =>
   Effect.gen(function* () {
     const invocationQueue = yield* Queue.unbounded<LambdaInvocation>()
     const responseQueue = yield* Queue.unbounded<
       LambdaResponse | LambdaError | LambdaInitError
     >()
+    const extensions = yield* Ref.make(HashMap.empty<string, ExtensionState>())
 
     return {
       invocationQueue,
       responseQueue,
+      extensions,
+      functionMetadata,
     } satisfies RuntimeApiState
   })
 
@@ -244,11 +275,235 @@ const handleInitError = (state: RuntimeApiState) =>
     return HttpServerResponse.empty({ status: 202 })
   })
 
+// ============================================================================
+// Extensions API handlers
+// @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html
+// ============================================================================
+
+/**
+ * Handle POST /2020-01-01/extension/register
+ * Extensions call this to register for lifecycle events.
+ */
+const handleExtensionRegister = (state: RuntimeApiState) =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest
+
+    // Get extension name from header (required)
+    const extensionNameHeader = Headers.get(
+      request.headers,
+      "lambda-extension-name",
+    )
+    const extensionName = Option.getOrElse(
+      extensionNameHeader,
+      () => "unknown-extension",
+    )
+
+    // Parse request body for events to register for
+    const body = yield* Effect.orElseSucceed(
+      request.json as Effect.Effect<{ events?: ExtensionEventType[] }, unknown>,
+      (): { events?: ExtensionEventType[] } => ({}),
+    )
+    const events: ExtensionEventType[] = body.events ?? ["INVOKE", "SHUTDOWN"]
+
+    // Generate unique extension ID
+    const extensionId = crypto.randomUUID()
+
+    // Create event queue for this extension
+    const eventQueue = yield* Queue.unbounded<ExtensionEvent>()
+
+    const extensionState: ExtensionState = {
+      extension: {
+        extensionId,
+        name: extensionName,
+        events,
+      },
+      eventQueue,
+    }
+
+    // Register the extension
+    yield* Ref.update(state.extensions, (exts) =>
+      HashMap.set(exts, extensionId, extensionState),
+    )
+
+    yield* Effect.logDebug(
+      `Extension registered: ${extensionName} (${extensionId}) for events: ${events.join(", ")}`,
+    )
+
+    return yield* HttpServerResponse.json(
+      {
+        functionName: state.functionMetadata.functionName,
+        functionVersion: state.functionMetadata.functionVersion,
+        handler: state.functionMetadata.handler,
+      },
+      {
+        status: 200,
+        headers: Headers.fromInput({
+          "Lambda-Extension-Identifier": extensionId,
+        }),
+      },
+    )
+  })
+
+/**
+ * Handle GET /2020-01-01/extension/event/next
+ * Extensions call this to poll for the next lifecycle event.
+ */
+const handleExtensionEventNext = (
+  state: RuntimeApiState,
+  pollTimeoutMs: number,
+) =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest
+
+    // Get extension ID from header (required)
+    const extensionIdHeader = Headers.get(
+      request.headers,
+      "lambda-extension-identifier",
+    )
+    const extensionId = Option.getOrElse(extensionIdHeader, () => "")
+
+    if (!extensionId) {
+      return HttpServerResponse.empty({
+        status: 403,
+        headers: Headers.fromInput({
+          "Content-Type": "application/json",
+        }),
+      })
+    }
+
+    // Find the extension
+    const extensions = yield* Ref.get(state.extensions)
+    const extensionState = HashMap.get(extensions, extensionId)
+
+    if (Option.isNone(extensionState)) {
+      yield* Effect.logDebug(`Extension not found: ${extensionId}`)
+      return HttpServerResponse.empty({
+        status: 403,
+        headers: Headers.fromInput({
+          "Content-Type": "application/json",
+        }),
+      })
+    }
+
+    const { eventQueue, extension } = extensionState.value
+
+    yield* Effect.logDebug(`Extension ${extension.name} polling for next event`)
+
+    const startTime = Date.now()
+
+    // Poll for the next event with timeout
+    let event: ExtensionEvent | null = null
+
+    while (event === null) {
+      if (Date.now() - startTime > pollTimeoutMs) {
+        yield* Effect.logDebug(
+          "Extension event poll timeout - returning 503 to trigger exit",
+        )
+        return HttpServerResponse.empty({
+          status: 503,
+          headers: Headers.fromInput({
+            "Content-Type": "application/json",
+          }),
+        })
+      }
+
+      const result = yield* Queue.poll(eventQueue)
+
+      if (Option.isSome(result)) {
+        event = result.value
+      } else {
+        yield* Effect.sleep("100 millis")
+      }
+    }
+
+    yield* Effect.logDebug(
+      `Returning ${event.eventType} event to extension ${extension.name}`,
+    )
+
+    return yield* HttpServerResponse.json(event, {
+      status: 200,
+      headers: Headers.fromInput({
+        "Lambda-Extension-Event-Identifier": crypto.randomUUID(),
+      }),
+    })
+  })
+
+/**
+ * Handle POST /2020-01-01/extension/init/error
+ * Extensions call this to report initialization errors.
+ */
+const handleExtensionInitError = (state: RuntimeApiState) =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest
+
+    const extensionIdHeader = Headers.get(
+      request.headers,
+      "lambda-extension-identifier",
+    )
+    const extensionId = Option.getOrElse(extensionIdHeader, () => "unknown")
+
+    const errorBody = yield* Effect.orElseSucceed(
+      request.json as Effect.Effect<
+        { errorMessage?: string; errorType?: string },
+        unknown
+      >,
+      (): { errorMessage?: string; errorType?: string } => ({}),
+    )
+
+    yield* Effect.logDebug(
+      `Extension ${extensionId} init error: ${errorBody.errorMessage ?? "unknown"}`,
+    )
+
+    // Report the error through the response queue
+    const initError: LambdaInitError = {
+      errorType: errorBody.errorType ?? "Extension.InitError",
+      errorMessage: errorBody.errorMessage ?? "Extension initialization failed",
+    }
+    yield* Queue.offer(state.responseQueue, initError)
+
+    return HttpServerResponse.empty({ status: 202 })
+  })
+
+/**
+ * Handle POST /2020-01-01/extension/exit/error
+ * Extensions call this to report errors before exiting.
+ */
+const handleExtensionExitError = () =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest
+
+    const extensionIdHeader = Headers.get(
+      request.headers,
+      "lambda-extension-identifier",
+    )
+    const extensionId = Option.getOrElse(extensionIdHeader, () => "unknown")
+
+    const errorBody = yield* Effect.orElseSucceed(
+      request.json as Effect.Effect<
+        { errorMessage?: string; errorType?: string },
+        unknown
+      >,
+      (): { errorMessage?: string; errorType?: string } => ({}),
+    )
+
+    yield* Effect.logDebug(
+      `Extension ${extensionId} exit error: ${errorBody.errorMessage ?? "unknown"}`,
+    )
+
+    // Just acknowledge - extension is exiting anyway
+    return HttpServerResponse.empty({ status: 202 })
+  })
+
+// ============================================================================
+// Router
+// ============================================================================
+
 /**
  * Create the Runtime API router for a given state.
  */
 const makeRuntimeApiRouter = (state: RuntimeApiState, pollTimeoutMs: number) =>
   HttpRouter.empty.pipe(
+    // Runtime API (2018-06-01)
     HttpRouter.get(
       "/2018-06-01/runtime/invocation/next",
       handleInvocationNext(state, pollTimeoutMs),
@@ -262,7 +517,40 @@ const makeRuntimeApiRouter = (state: RuntimeApiState, pollTimeoutMs: number) =>
       handleInvocationError(state),
     ),
     HttpRouter.post("/2018-06-01/runtime/init/error", handleInitError(state)),
+    // Extensions API (2020-01-01)
+    HttpRouter.post(
+      "/2020-01-01/extension/register",
+      handleExtensionRegister(state),
+    ),
+    HttpRouter.get(
+      "/2020-01-01/extension/event/next",
+      handleExtensionEventNext(state, pollTimeoutMs),
+    ),
+    HttpRouter.post(
+      "/2020-01-01/extension/init/error",
+      handleExtensionInitError(state),
+    ),
+    HttpRouter.post(
+      "/2020-01-01/extension/exit/error",
+      handleExtensionExitError(),
+    ),
   )
+
+/**
+ * Options for starting a Runtime API server.
+ */
+export interface RuntimeApiServerOptions {
+  /** How long to wait for an invocation before returning 503 */
+  pollTimeoutMs?: number
+  /** Function metadata for extension registration */
+  functionMetadata?: FunctionMetadata
+}
+
+const DEFAULT_FUNCTION_METADATA: FunctionMetadata = {
+  functionName: "local-function",
+  functionVersion: "$LATEST",
+  handler: "index.handler",
+}
 
 /**
  * Start a Runtime API server on an ephemeral port.
@@ -270,15 +558,18 @@ const makeRuntimeApiRouter = (state: RuntimeApiState, pollTimeoutMs: number) =>
  *
  * The server is scoped - it will be stopped when the scope closes.
  *
- * @param pollTimeoutMs - How long to wait for an invocation before returning 503.
- *                        Defaults to DEFAULT_POLL_TIMEOUT_MS.
+ * @param options - Server configuration options
  */
 export const startRuntimeApiServer = (
-  pollTimeoutMs: number = DEFAULT_POLL_TIMEOUT_MS,
+  options: RuntimeApiServerOptions = {},
 ): Effect.Effect<RuntimeApiServer, never, Scope.Scope> =>
   Effect.gen(function* () {
+    const pollTimeoutMs = options.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS
+    const functionMetadata =
+      options.functionMetadata ?? DEFAULT_FUNCTION_METADATA
+
     // Create state (queues) for this server
-    const state = yield* makeRuntimeApiState()
+    const state = yield* makeRuntimeApiState(functionMetadata)
 
     // Create router for this state
     const router = makeRuntimeApiRouter(state, pollTimeoutMs)
@@ -325,3 +616,60 @@ export const waitForResponse = (
   state: RuntimeApiState,
 ): Effect.Effect<LambdaResponse | LambdaError | LambdaInitError> =>
   Queue.take(state.responseQueue)
+
+/**
+ * Notify all registered extensions about an invocation.
+ * This sends an INVOKE event to all extensions that registered for it.
+ */
+export const notifyExtensionsInvoke = (
+  state: RuntimeApiState,
+  invocation: LambdaInvocation,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const extensions = yield* Ref.get(state.extensions)
+
+    const invokeEvent: ExtensionEvent = {
+      eventType: "INVOKE",
+      deadlineMs: invocation.deadlineMs,
+      requestId: invocation.requestId,
+      invokedFunctionArn: invocation.invokedFunctionArn,
+    }
+
+    // Send INVOKE event to all extensions that registered for it
+    for (const [, extState] of extensions) {
+      if (extState.extension.events.includes("INVOKE")) {
+        yield* Queue.offer(extState.eventQueue, invokeEvent)
+        yield* Effect.logDebug(
+          `Sent INVOKE event to extension ${extState.extension.name}`,
+        )
+      }
+    }
+  })
+
+/**
+ * Notify all registered extensions about shutdown.
+ * This sends a SHUTDOWN event to all extensions that registered for it.
+ */
+export const notifyExtensionsShutdown = (
+  state: RuntimeApiState,
+  reason: "SPINDOWN" | "TIMEOUT" | "FAILURE" = "SPINDOWN",
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const extensions = yield* Ref.get(state.extensions)
+
+    const shutdownEvent: ExtensionEvent = {
+      eventType: "SHUTDOWN",
+      shutdownReason: reason,
+      deadlineMs: Date.now() + 2000, // 2 second deadline for shutdown
+    }
+
+    // Send SHUTDOWN event to all extensions that registered for it
+    for (const [, extState] of extensions) {
+      if (extState.extension.events.includes("SHUTDOWN")) {
+        yield* Queue.offer(extState.eventQueue, shutdownEvent)
+        yield* Effect.logDebug(
+          `Sent SHUTDOWN event to extension ${extState.extension.name}`,
+        )
+      }
+    }
+  })

--- a/src/cli/runtime-api/types.ts
+++ b/src/cli/runtime-api/types.ts
@@ -97,3 +97,58 @@ export interface InvocationNextHeaders {
   "Lambda-Runtime-Log-Stream-Name"?: string
   "Lambda-Runtime-Trace-Id"?: string
 }
+
+/**
+ * Event types that extensions can register for.
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html
+ */
+export type ExtensionEventType = "INVOKE" | "SHUTDOWN"
+
+/**
+ * Registered extension information.
+ */
+export interface RegisteredExtension {
+  /** Unique identifier for the extension (UUID) */
+  extensionId: string
+  /** Name of the extension (from Lambda-Extension-Name header) */
+  name: string
+  /** Events this extension is registered for */
+  events: ExtensionEventType[]
+}
+
+/**
+ * Extension INVOKE event payload.
+ */
+export interface ExtensionInvokeEvent {
+  eventType: "INVOKE"
+  deadlineMs: number
+  requestId: string
+  invokedFunctionArn: string
+  tracing?: {
+    type: string
+    value: string
+  }
+}
+
+/**
+ * Extension SHUTDOWN event payload.
+ */
+export interface ExtensionShutdownEvent {
+  eventType: "SHUTDOWN"
+  shutdownReason: "SPINDOWN" | "TIMEOUT" | "FAILURE"
+  deadlineMs: number
+}
+
+/**
+ * Extension event (either INVOKE or SHUTDOWN).
+ */
+export type ExtensionEvent = ExtensionInvokeEvent | ExtensionShutdownEvent
+
+/**
+ * Response body for extension registration.
+ */
+export interface ExtensionRegisterResponse {
+  functionName: string
+  functionVersion: string
+  handler: string
+}


### PR DESCRIPTION
## Summary

- Add Lambda Extensions API support to the local Runtime API server
- Automatically start Lambda extensions in Docker containers
- Enable AWS Lambda Web Adapter to work locally without Dockerfile changes

## Changes

### Extensions API (`src/cli/runtime-api/server.ts`, `types.ts`)
- Implement `POST /2020-01-01/extension/register` - Extension registration
- Implement `GET /2020-01-01/extension/event/next` - Poll for lifecycle events
- Implement `POST /2020-01-01/extension/init/error` - Report init errors
- Implement `POST /2020-01-01/extension/exit/error` - Report exit errors
- Add extension state management and event queues

### Docker Extension Wrapper (`src/cli/docker/container.ts`, `types.ts`)
- Add `inspect()` method to retrieve image ENTRYPOINT/CMD
- Add `buildExtensionWrapperCommand()` to generate shell wrapper
- Override container entrypoint to start `/opt/extensions/*` before the app

### Integration (`src/cli/commands/local.ts`)
- Inspect Docker images after build to get original command
- Apply extension wrapper transparently at container startup
- Notify extensions about invocations via `notifyExtensionsInvoke()`

## Testing

- Local: Lambda Web Adapter extension registers and forwards invocations correctly
- AWS: Same Dockerfile works unchanged (AWS starts extensions natively)

## Example

The `examples/complete/functions/echo` handler now uses AWS Lambda Web Adapter:
- Runs as a Bun HTTP server on port 8080
- Works both locally (via our extension wrapper) and in AWS (via native extension support)