### PR TITLE
fix: update repository URLs to match npm provenance

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -11,10 +11,10 @@ const project = new typescript.TypeScriptProject({
   // Package metadata
   description:
     "CLI and CDK Aspect for running Lambda functions locally via AppSync Events WebSocket relay",
-  repository: "https://github.com/berenddeboer/cdk-local-lambda.git",
-  homepage: "https://github.com/berenddeboer/cdk-local-lambda#readme",
+  repository: "https://github.com/processfocus/cdk-local-lambda.git",
+  homepage: "https://github.com/processfocus/cdk-local-lambda#readme",
   authorName: "Berend de Boer",
-  bugsUrl: "https://github.com/berenddeboer/cdk-local-lambda/issues",
+  bugsUrl: "https://github.com/processfocus/cdk-local-lambda/issues",
   keywords: [
     "aws",
     "aws-cdk",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "CLI and CDK Aspect for running Lambda functions locally via AppSync Events WebSocket relay",
   "repository": {
     "type": "git",
-    "url": "https://github.com/berenddeboer/cdk-local-lambda.git"
+    "url": "https://github.com/processfocus/cdk-local-lambda.git"
   },
   "bin": {
     "local-lambda": "lib/cli/index.js"
@@ -81,13 +81,13 @@
   ],
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/berenddeboer/cdk-local-lambda#readme",
+  "homepage": "https://github.com/processfocus/cdk-local-lambda#readme",
   "publishConfig": {
     "access": "public"
   },
   "version": "0.0.0",
   "bugs": {
-    "url": "https://github.com/berenddeboer/cdk-local-lambda/issues"
+    "url": "https://github.com/processfocus/cdk-local-lambda/issues"
   },
   "types": "lib/index.d.ts",
   "type": "module",


### PR DESCRIPTION
Fixes npm publish error E422 by updating repository URLs from `berenddeboer/cdk-local-lambda` to `processfocus/cdk-local-lambda`.

The npm provenance attestation generated by GitHub Actions was failing validation because the repository URL in package.json didn't match the provenance bundle. This updates all URLs (repository, homepage, bugs) to use the correct `processfocus` organization.

**Error fixed:**
```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/local-live-lambda
Error verifying sigstore provenance bundle: Failed to validate repository information
```