### PR TITLE
refactor: rename CLI from cdk-local-lambda to cll

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -119,7 +119,7 @@ project.addTask("test:integration", {
 })
 
 // Add bin entry for CLI
-project.addBins({ "cdk-local-lambda": "lib/cli/index.js" })
+project.addBins({ cll: "lib/cli/index.js" })
 
 // Set package type to module for ESM support
 project.package.addField("type", "module")

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Run lambdas in CDK stack locally
 
-Run typescript and docker lambdas in a standard CDK stack
-locally. This improves the DX as you can edit lambdas and see changes
-and fixes immediately.
+Run typescript and docker lambdas in a CDK stack locally. This
+improves the DX as you can edit lambdas and see changes and fixes
+immediately.
 
-Only two minor changes to your CDK stack are needed.
+Needs two minor changes to a CDK stack, and the supplied cli to launch it.
 
 ## Installation
 
@@ -64,19 +64,19 @@ app.synth()
 The daemon deploys your stack with live mode enabled and runs your Lambda functions locally:
 
 ```bash
-npx cdk-local-lambda local
+npx cll local
 ```
 
 If you have multiple stacks:
 
 ```bash
-npx cdk-local-lambda local --stacks MyStack
+npx cll local --stacks MyStack
 ```
 
 Use `--profile` and `--region` to specify AWS credentials:
 
 ```bash
-npx cdk-local-lambda local --stacks MyStack --profile my-profile --region us-west-2
+npx cll local --stacks MyStack --profile my-profile --region us-west-2
 ```
 
 ### Manual bootstrap (optional)
@@ -84,7 +84,7 @@ npx cdk-local-lambda local --stacks MyStack --profile my-profile --region us-wes
 If you prefer to deploy the bootstrap stack separately:
 
 ```bash
-npx cdk-local-lambda bootstrap --profile my-profile --region us-west-2
+npx cll bootstrap --profile my-profile --region us-west-2
 ```
 
 ## Common issues

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/processfocus/cdk-local-lambda.git"
   },
   "bin": {
-    "cdk-local-lambda": "lib/cli/index.js"
+    "cll": "lib/cli/index.js"
   },
   "scripts": {
     "build": "npx projen build",


### PR DESCRIPTION
Renames the CLI command from `cdk-local-lambda` to the shorter `cll`.

## Changes

- Updated `.projenrc.ts` to change the bin entry from `cdk-local-lambda` to `cll`
- Updated all CLI examples in README.md to use `npx cll` instead of `npx cdk-local-lambda`
- Regenerated `package.json` with the new bin name