### PR TITLE
fix: correct misleading logs and worker request prefixes

### DIFF
--- a/src/aspect/live-lambda-aspect.ts
+++ b/src/aspect/live-lambda-aspect.ts
@@ -106,15 +106,15 @@ export class LiveLambdaAspect implements cdk.IAspect {
       return
     }
 
-    console.log(`[LiveLambda] Transforming function: ${functionId}`)
-
     const stackName = this.props.stackName || cdk.Stack.of(fn).stackName
 
     // Check if this is a DockerImageFunction
     const isDockerFunction = isDockerImageFunction(fn)
 
     if (isDockerFunction) {
-      console.log(`[LiveLambda] Detected DockerImageFunction: ${functionId}`)
+      console.log(
+        `[LiveLambda] Transforming DockerImageFunction: ${functionId}`,
+      )
       this.transformDockerFunction(fn, stackName, functionId)
     } else {
       // Get handler paths before we modify anything
@@ -122,10 +122,13 @@ export class LiveLambdaAspect implements cdk.IAspect {
 
       // Skip unsupported functions (not NodejsFunction or DockerImageFunction)
       if (!handlerPaths) {
+        this.processedFunctions.add(nodeId)
         return
       }
 
       const { originalHandler, localHandler } = handlerPaths
+
+      console.log(`[LiveLambda] Transforming function: ${functionId}`)
 
       // Transform the function
       this.transformFunction(

--- a/src/cli/commands/local.ts
+++ b/src/cli/commands/local.ts
@@ -134,6 +134,8 @@ interface NodejsWorker {
   workerProcess: ChildProcess
   /** Environment variables captured from first invocation */
   env: Record<string, string>
+  /** Currently processing request ID for log prefixing */
+  currentRequestId: string | undefined
 }
 
 /**
@@ -608,6 +610,7 @@ const startNodejsWorker = (
   projectRoot: string,
   env: Record<string, string>,
   invocationContexts: Map<string, InvocationContext>,
+  worker: NodejsWorker,
 ): Effect.Effect<ChildProcess, Error> =>
   Effect.gen(function* () {
     if (!fn.localHandler) {
@@ -679,6 +682,13 @@ const startNodejsWorker = (
         if (ctx) {
           // Strip timestamp and request ID, keep just LEVEL MESSAGE
           return { prefix: `[${ctx.num}]`, content: match[3] }
+        }
+      }
+      // Fallback to worker's current request ID for logs without request ID
+      if (worker.currentRequestId) {
+        const ctx = invocationContexts.get(worker.currentRequestId)
+        if (ctx) {
+          return { prefix: `[${ctx.num}]`, content: line }
         }
       }
       return { prefix: "[Worker]", content: line }
@@ -780,6 +790,9 @@ const processWorkerResponses = (
         }
         invocationContexts.delete(response.requestId)
       }
+
+      // Clear current request ID to prevent stale prefixes
+      worker.currentRequestId = undefined
     }
   })
 
@@ -910,6 +923,7 @@ const ensureWorkerStarted = (
       port,
       workerProcess: undefined as unknown as ChildProcess, // Will be set shortly
       env: invocationEnv,
+      currentRequestId: undefined,
     }
 
     // Add to map immediately to prevent race conditions
@@ -923,6 +937,7 @@ const ensureWorkerStarted = (
       projectRoot,
       invocationEnv,
       invocationContexts,
+      worker,
     ).pipe(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
@@ -1399,6 +1414,9 @@ const handleNodejsInvocation = (
       logGroupName: invocation.context.logGroupName,
       logStreamName: invocation.context.logStreamName,
     }
+
+    // Track current request ID for log prefixing
+    worker.currentRequestId = invocation.requestId
 
     yield* queueInvocation(worker.runtimeState, lambdaInvocation)
   })

--- a/todo.org
+++ b/todo.org
@@ -1,9 +1,14 @@
-* TODO Rename cli to cll
+* DONE Rename cli to cll
+CLOSED: [2026-01-31 Sat 10:12]
 * TODO Update README with clear install instructions
+* IN-PROGRESS Replace [Worker] prefix with request number
+* TODO Refer to SST v2
+* TODO Document what doesn't work
 * TODO Add labmda trigger via bucket to example stack
 * TODO It seems we open many subscriptions to wss, could we use just one?
 * TODO Use CDK_LOCAL_LAMBDA instead of CDK_LIVE?
-* TODO Found 2 related issues with the graceful skip implementation:
+* TODO Add screenshot of what it looks like
+* IN-PROGRESS Found 2 related issues with the graceful skip implementation:
 
 Issue 1: Misleading log message - Line 109 logs 'Transforming function' before checking if the function will actually be skipped. Move this log after the null check at line 128.
 
@@ -100,5 +105,4 @@ Missed entire architecture
 - we didn't get cdk deploy and live mode with daemon
 - docker image was not a replacement
 * TODO Rename complete stack to LocalLiveLambdaExample
-* Send patch to CDK to make entry & hander visible.
-* TODO Switch repo to processfocus: free publicity
+* TODO Send patch to CDK to make entry & hander visible.


### PR DESCRIPTION
## Summary

This PR fixes two issues:

### Aspect Fixes
- **Misleading log message**: Moved 'Transforming function' log after the null check to avoid confusing logs when functions are skipped
- **Repeated processing**: Added  before the early return when  returns null, preventing the same unsupported function from being processed repeatedly

### Worker Log Prefix Fix
- **Request attribution**: Worker stdout/stderr lines that don't contain a Lambda request ID now use the current invocation's request number prefix (e.g., ) instead of generic 
- **Track current request**: Added  field to  interface to track the active invocation
- **Clear on completion**: Reset  after each invocation completes to prevent stale prefixes

## Changes
- : Fixed log placement and added tracking for skipped functions
- : Added request tracking for proper log prefixing