### PR TITLE
feat: enable minor version bumps for feat commits in 0.x versions

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -33,6 +33,7 @@
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
         "RELEASE_TAG_PREFIX": "",
+        "VERSIONRCOPTIONS": "{\"preMajor\":false}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12"
       },
       "steps": [
@@ -233,6 +234,7 @@
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
         "RELEASE_TAG_PREFIX": "",
+        "VERSIONRCOPTIONS": "{\"preMajor\":false}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12"
       },
       "steps": [

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -8,6 +8,11 @@ const project = new typescript.TypeScriptProject({
   eslint: false,
   jest: false, // Use Bun's built-in test runner instead
 
+  // Allow feat commits to trigger minor bumps even in 0.x versions
+  versionrcOptions: {
+    preMajor: false,
+  },
+
   // Package metadata
   description:
     "Run lambdas in CDK stack locally to speed up debugging and improve your DX",


### PR DESCRIPTION
## Summary

- Disables `preMajor` behavior in commit-and-tag-version so that `feat:` commits trigger **minor** bumps (0.0.x → 0.1.0) instead of patch bumps
- This allows proper semver semantics even while in the 0.x version range

## Background

By default, `commit-and-tag-version` sets `preMajor: true` for versions < 1.0.0, which downgrades:
- `feat` → patch (instead of minor)
- `BREAKING CHANGE` → minor (instead of major)

Setting `preMajor: false` restores standard conventional commit behavior.