### PR TITLE
chore: revert preMajor option (did not affect version bumping)

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -33,7 +33,6 @@
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
         "RELEASE_TAG_PREFIX": "",
-        "VERSIONRCOPTIONS": "{\"preMajor\":false}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12"
       },
       "steps": [
@@ -234,7 +233,6 @@
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
         "RELEASE_TAG_PREFIX": "",
-        "VERSIONRCOPTIONS": "{\"preMajor\":false}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12"
       },
       "steps": [

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -8,11 +8,6 @@ const project = new typescript.TypeScriptProject({
   eslint: false,
   jest: false, // Use Bun's built-in test runner instead
 
-  // Allow feat commits to trigger minor bumps even in 0.x versions
-  versionrcOptions: {
-    preMajor: false,
-  },
-
   // Package metadata
   description:
     "Run lambdas in CDK stack locally to speed up debugging and improve your DX",


### PR DESCRIPTION
Removes the `versionrcOptions: { preMajor: false }` setting since it didn't change the version bump behavior.