### PR TITLE
feat: add isInLocalMode for conditional configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ To deploy the bootstrap stack separately:
 npx cll bootstrap --profile my-profile --region us-west-2
 ```
 
+## Options
+
+### Conditional Configuration
+
+Use `isInLocalMode()` to conditionally configure your constructs when running locally:
+
+```typescript
+import { isInLocalMode } from "cdk-local-lambda"
+
+new lambda.Function(this, "MyFunction", {
+  // Longer timeout for local debugging
+  timeout: isInLocalMode()
+    ? cdk.Duration.minutes(5)
+    : cdk.Duration.seconds(30),
+  // ... other props
+})
+```
+
 ## Troubleshooting
 
 ### "No functions found with live-lambda tags yet"

--- a/examples/complete/lib/complete-stack.ts
+++ b/examples/complete/lib/complete-stack.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from "node:url"
 import * as cdk from "aws-cdk-lib"
 import * as lambda from "aws-cdk-lib/aws-lambda"
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs"
+import { isInLocalMode } from "cdk-local-lambda"
 import type { Construct } from "constructs"
 
 // ESM equivalent of __dirname
@@ -52,7 +53,10 @@ export class CompleteStack extends cdk.Stack {
       ),
       architecture: lambda.Architecture.ARM_64,
       memorySize: 256,
-      timeout: cdk.Duration.seconds(30),
+      // Conditional timeout: longer in local mode for debugging
+      timeout: isInLocalMode()
+        ? cdk.Duration.minutes(5)
+        : cdk.Duration.seconds(30),
       description: "Docker echo function - returns the input event",
     })
 
@@ -63,7 +67,10 @@ export class CompleteStack extends cdk.Stack {
       ),
       architecture: lambda.Architecture.X86_64,
       memorySize: 256,
-      timeout: cdk.Duration.seconds(30),
+      // Conditional timeout: longer in local mode for debugging
+      timeout: isInLocalMode()
+        ? cdk.Duration.minutes(5)
+        : cdk.Duration.seconds(30),
       description: "Docker adder function - adds two numbers",
       environment: {
         TEST: "12345",
@@ -77,7 +84,10 @@ export class CompleteStack extends cdk.Stack {
       runtime: lambda.Runtime.NODEJS_24_X,
       architecture: lambda.Architecture.ARM_64,
       memorySize: 256,
-      timeout: cdk.Duration.seconds(30),
+      // Conditional timeout: longer in local mode for debugging
+      timeout: isInLocalMode()
+        ? cdk.Duration.minutes(5)
+        : cdk.Duration.seconds(30),
       description: "TypeScript greeter function",
     })
 
@@ -94,7 +104,10 @@ export class CompleteStack extends cdk.Stack {
       runtime: lambda.Runtime.NODEJS_24_X,
       architecture: lambda.Architecture.X86_64,
       memorySize: 256,
-      timeout: cdk.Duration.seconds(30),
+      // Conditional timeout: longer in local mode for debugging
+      timeout: isInLocalMode()
+        ? cdk.Duration.minutes(5)
+        : cdk.Duration.seconds(30),
       description: "JavaScript calculator function",
     })
 

--- a/src/aspect/live-lambda-aspect.ts
+++ b/src/aspect/live-lambda-aspect.ts
@@ -303,9 +303,6 @@ export class LiveLambdaAspect implements cdk.IAspect {
       }),
     )
 
-    // Increase timeout to allow for local debugging
-    cfnFunction.timeout = 300 // 5 minutes
-
     // Replace the Docker image with the bridge image
     cfnFunction.code = {
       imageUri: bridgeImageUri,
@@ -386,9 +383,6 @@ export class LiveLambdaAspect implements cdk.IAspect {
       }),
     )
 
-    // Increase timeout to allow for local debugging
-    cfnFunction.timeout = 300 // 5 minutes
-
     // Replace the code with bridge handler from bootstrap stack's S3 bucket
     cfnFunction.code = {
       s3Bucket: bridgeBucket,
@@ -399,9 +393,15 @@ export class LiveLambdaAspect implements cdk.IAspect {
 }
 
 /**
- * Helper function to check if live mode is enabled
+ * Check if local mode is enabled (CDK_LOCAL_LAMBDA=true).
+ * Use this in your constructs for conditional configuration.
+ *
+ * @example
+ * timeout: isInLocalMode()
+ *   ? cdk.Duration.minutes(5)
+ *   : cdk.Duration.seconds(30)
  */
-export function isLiveModeEnabled(): boolean {
+export function isInLocalMode(): boolean {
   return process.env.CDK_LOCAL_LAMBDA === "true"
 }
 
@@ -415,7 +415,7 @@ export function applyLiveLambdaAspect(
   scope: IConstruct,
   props: LiveLambdaAspectProps = {},
 ): void {
-  if (!isLiveModeEnabled()) {
+  if (!isInLocalMode()) {
     console.log(
       "[LiveLambda] Live mode not enabled (set CDK_LOCAL_LAMBDA=true to enable)",
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * Exports:
  * - LiveLambdaAspect: CDK Aspect to transform Lambda functions
  * - applyLiveLambdaAspect: Helper to apply the aspect if CDK_LOCAL_LAMBDA=true
- * - isLiveModeEnabled: Check if live mode is enabled
+ * - isInLocalMode: Check if local mode is enabled
  * - CdkLocalLambdaBootstrapStack: The bootstrap stack for shared infrastructure
  *
  * For Docker function support, you must install the bootstrap BEFORE any CDK
@@ -23,7 +23,7 @@
 // Re-export the aspect and helpers
 export {
   applyLiveLambdaAspect,
-  isLiveModeEnabled,
+  isInLocalMode,
   LiveLambdaAspect,
   type LiveLambdaAspectProps,
 } from "./aspect/live-lambda-aspect.js"

--- a/test/live-lambda-aspect.test.ts
+++ b/test/live-lambda-aspect.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test } from "bun:test"
-import { isLiveModeEnabled, LiveLambdaAspect } from "../src"
+import { isInLocalMode, LiveLambdaAspect } from "../src"
 
-test("isLiveModeEnabled returns false when CDK_LOCAL_LAMBDA is not set", () => {
+test("isInLocalMode returns false when CDK_LOCAL_LAMBDA is not set", () => {
   delete process.env.CDK_LOCAL_LAMBDA
-  expect(isLiveModeEnabled()).toBe(false)
+  expect(isInLocalMode()).toBe(false)
 })
 
-test("isLiveModeEnabled returns true when CDK_LOCAL_LAMBDA is true", () => {
+test("isInLocalMode returns true when CDK_LOCAL_LAMBDA is true", () => {
   process.env.CDK_LOCAL_LAMBDA = "true"
-  expect(isLiveModeEnabled()).toBe(true)
+  expect(isInLocalMode()).toBe(true)
   delete process.env.CDK_LOCAL_LAMBDA
 })
 


### PR DESCRIPTION
## Summary

This PR exposes local mode detection to users through a new `isInLocalMode()` function, allowing conditional configuration of Lambda functions and other constructs when running in local mode.

## Changes

- **Breaking**: Rename `isLiveModeEnabled()` to `isInLocalMode()` for clearer API terminology
- Remove hardcoded `timeout = 300` override from `LiveLambdaAspect` (users can now use `isInLocalMode()` in their stack code)
- Add new "Options" section to README documenting conditional configuration
- Update example stack to demonstrate conditional timeout based on local mode

## Usage

Users can now conditionally configure their functions:

```typescript
import { isInLocalMode } from "cdk-local-lambda"

new lambda.Function(this, "MyFunction", {
  timeout: isInLocalMode()
    ? cdk.Duration.minutes(5)  // Longer timeout for debugging
    : cdk.Duration.seconds(30),
})
```

## Migration

Replace any usage of `isLiveModeEnabled()` with `isInLocalMode()`:

```diff
- import { isLiveModeEnabled } from "cdk-local-lambda"
+ import { isInLocalMode } from "cdk-local-lambda"

- if (isLiveModeEnabled()) {
+ if (isInLocalMode()) {
```