### PR TITLE
fix(ci): use GITHUB_TOKEN for upgrade-trunk workflow

### DIFF
--- a/.github/workflows/upgrade-trunk.yml
+++ b/.github/workflows/upgrade-trunk.yml
@@ -45,7 +45,8 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     if: ${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
@@ -67,7 +68,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |-
             chore(deps): upgrade dependencies
 

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,4 @@
-import { javascript, typescript } from "projen"
+import { github, javascript, typescript } from "projen"
 
 const project = new typescript.TypeScriptProject({
   defaultReleaseBranch: "trunk",
@@ -33,6 +33,15 @@ const project = new typescript.TypeScriptProject({
   npmProvenance: true,
   workflowNodeVersion: "24.x",
   npmTrustedPublishing: true,
+
+  // Use GITHUB_TOKEN for dependency upgrades (no separate PAT needed)
+  depsUpgradeOptions: {
+    workflowOptions: {
+      projenCredentials: github.GithubCredentials.fromPersonalAccessToken({
+        secret: "GITHUB_TOKEN",
+      }),
+    },
+  },
 
   // Enable ESM package type
   entrypoint: "lib/index.js",
@@ -143,6 +152,14 @@ project.github
     "jobs.validate.steps.0.with.types",
     "ci\nfeat\nfix\nchore\nrefactor\ntest\nvendor",
   )
+
+// Fix upgrade-trunk workflow permissions for GITHUB_TOKEN to create PRs
+project.github
+  ?.tryFindWorkflow("upgrade-trunk")
+  ?.file?.addOverride("jobs.pr.permissions", {
+    contents: "write",
+    "pull-requests": "write",
+  })
 
 // Specify files to include in npm package
 project.package.addField("files", ["lib", "LICENSE", "README.md"])


### PR DESCRIPTION
## Summary

- Fix the `upgrade-trunk` workflow which failed because `PROJEN_GITHUB_TOKEN` was not configured
- Use built-in `GITHUB_TOKEN` with proper permissions (`contents: write`, `pull-requests: write`) for PR creation

Fixes: https://github.com/processfocus/cdk-local-lambda/actions/runs/21535602573