### PR TITLE
fix(cli): remove shell:true to fix DEP0190 and add CommonJS exports

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -183,15 +183,17 @@ project.github
 // Specify files to include in npm package
 project.package.addField("files", ["lib", "LICENSE", "README.md"])
 
-// Add exports field for clean subpath imports
+// Add exports field for clean subpath imports (supports both ESM and CommonJS for ts-node)
 project.package.addField("exports", {
   ".": {
     types: "./lib/index.d.ts",
     import: "./lib/index.js",
+    require: "./lib/index.js",
   },
   "./bootstrap": {
     types: "./lib/aspect/live-lambda-bootstrap.d.ts",
     import: "./lib/aspect/live-lambda-bootstrap.js",
+    require: "./lib/aspect/live-lambda-bootstrap.js",
   },
   "./package.json": "./package.json",
 })

--- a/package.json
+++ b/package.json
@@ -98,11 +98,13 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib/index.js"
     },
     "./bootstrap": {
       "types": "./lib/aspect/live-lambda-bootstrap.d.ts",
-      "import": "./lib/aspect/live-lambda-bootstrap.js"
+      "import": "./lib/aspect/live-lambda-bootstrap.js",
+      "require": "./lib/aspect/live-lambda-bootstrap.js"
     },
     "./package.json": "./package.json"
   },

--- a/src/cli/commands/local.ts
+++ b/src/cli/commands/local.ts
@@ -1473,7 +1473,6 @@ const startCdkWatch = (
 
     const command = PlatformCommand.make("npx", ...args).pipe(
       PlatformCommand.env(env),
-      PlatformCommand.runInShell(true),
       PlatformCommand.stdin("inherit"),
     )
 


### PR DESCRIPTION
## Summary

This PR fixes two issues that affect users running the CLI:

### 1. Fix DEP0190 deprecation warning
Removed `PlatformCommand.runInShell(true)` from the CDK watch command to eliminate the Node.js DEP0190 deprecation warning about security vulnerabilities when passing arguments to shell processes.

### 2. Add CommonJS support for ts-node
Added `require` conditions to the exports field for both the main entry point (`.") and the `./bootstrap` subpath. This allows the package to work with ts-node and other CommonJS consumers.

### Changes
- `src/cli/commands/local.ts`: Remove `runInShell(true)` 
- `.projenrc.ts`: Add `require` condition to exports
- `package.json`: Regenerated from projen

## Testing
- Build passes
- All tests pass (75 tests)
- Package can now be resolved with both ESM `import` and CommonJS `require`