### PR TITLE
fix: fix bridge bundling and add bootstrap version checking

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -166,7 +166,7 @@
       "description": "Runs after successful compilation",
       "steps": [
         {
-          "exec": "mkdir -p lib/functions/bridge && bun build src/functions/bridge/handler.ts --outfile=lib/functions/bridge/index.js --target=node --format=cjs --bundle --external=@aws-sdk/*"
+          "exec": "mkdir -p lib/functions/bridge && bun build src/functions/bridge/handler.ts --outfile=lib/functions/bridge/index.mjs --target=node --format=esm --bundle --external=@aws-sdk/*"
         },
         {
           "exec": "bun build src/functions/bridge-docker/runtime.ts --outfile=src/functions/bridge-docker/runtime.js --target=node --format=cjs --bundle"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -62,6 +62,8 @@ const project = new typescript.TypeScriptProject({
   },
   tsconfigDev: {
     compilerOptions: {
+      rootDir: ".",
+      outDir: "lib",
       module: "ESNext",
       moduleResolution: javascript.TypeScriptModuleResolution.BUNDLER,
       target: "ES2024",
@@ -108,8 +110,9 @@ project.defaultTask?.reset("tsx .projenrc.ts")
 
 // Bundle bridge handler after TypeScript compilation
 // This pre-bundles the bridge so users don't need to compile it at CDK synth time
+// Using ESM format with .mjs extension for proper Lambda module loading
 project.postCompileTask.exec(
-  "mkdir -p lib/functions/bridge && bun build src/functions/bridge/handler.ts --outfile=lib/functions/bridge/index.js --target=node --format=cjs --bundle --external=@aws-sdk/*",
+  "mkdir -p lib/functions/bridge && bun build src/functions/bridge/handler.ts --outfile=lib/functions/bridge/index.mjs --target=node --format=esm --bundle --external=@aws-sdk/*",
 )
 
 // Bundle Docker bridge runtime to src/, then copy whole directory to lib/

--- a/src/cli/commands/bootstrap.ts
+++ b/src/cli/commands/bootstrap.ts
@@ -4,7 +4,11 @@ import * as path from "node:path"
 import { fileURLToPath } from "node:url"
 import { Command, Options } from "@effect/cli"
 import { Console, Effect, Option } from "effect"
-import { BOOTSTRAP_STACK_NAME } from "../../shared/types.js"
+import {
+  BOOTSTRAP_STACK_NAME,
+  BOOTSTRAP_VERSION,
+  SSM_BASE_PATH,
+} from "../../shared/types.js"
 
 // ESM equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url)
@@ -37,14 +41,78 @@ const regionOption = Options.text("region").pipe(
 )
 
 /**
+ * Get the currently deployed bootstrap version from SSM.
+ * Returns undefined if not deployed or parameter doesn't exist.
+ */
+function getDeployedVersion(
+  profile: Option.Option<string>,
+  region: Option.Option<string>,
+): string | undefined {
+  const env = { ...process.env }
+  if (Option.isSome(region)) {
+    env.AWS_REGION = region.value
+    env.CDK_DEFAULT_REGION = region.value
+  }
+
+  const args = [
+    "ssm",
+    "get-parameter",
+    "--name",
+    `${SSM_BASE_PATH}/hnb659fds/version`,
+    "--query",
+    "Parameter.Value",
+    "--output",
+    "text",
+  ]
+  if (Option.isSome(profile)) {
+    args.push("--profile", profile.value)
+  }
+
+  try {
+    const result = execSync(`aws ${args.join(" ")}`, {
+      env,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    })
+    return result.trim()
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Bootstrap command - deploys the CdkLocalLambdaBootstrapStack
+ * Only deploys if the required version is newer than the deployed version.
+ * Skips deployment if deployed version is already equal or newer.
  */
 export const bootstrapCommand = Command.make(
   "bootstrap",
   { profile: profileOption, region: regionOption },
   ({ profile, region }) =>
     Effect.gen(function* () {
-      yield* Console.log("Deploying bootstrap stack...")
+      yield* Console.log("Checking bootstrap stack version...")
+
+      const deployedVersion = getDeployedVersion(profile, region)
+      const requiredVersion = BOOTSTRAP_VERSION
+
+      if (deployedVersion) {
+        const deployed = parseInt(deployedVersion, 10)
+        const required = parseInt(requiredVersion, 10)
+
+        if (deployed >= required) {
+          yield* Console.log(
+            `Bootstrap stack version ${deployedVersion} is already deployed (required: ${requiredVersion}). Skipping deployment.`,
+          )
+          return
+        }
+        yield* Console.log(
+          `Upgrading bootstrap stack from version ${deployedVersion} to ${requiredVersion}...`,
+        )
+      } else {
+        yield* Console.log(
+          `No bootstrap stack found. Deploying version ${requiredVersion}...`,
+        )
+      }
 
       // Path to the CDK app that defines the bootstrap stack
       const cdkAppPath = getCdkAppPath()

--- a/src/cli/commands/local.ts
+++ b/src/cli/commands/local.ts
@@ -12,6 +12,7 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process"
+import * as fs from "node:fs"
 import * as path from "node:path"
 import { fileURLToPath } from "node:url"
 import {
@@ -74,6 +75,23 @@ import type {
   LambdaInvocation,
   LambdaResponse,
 } from "../runtime-api/types.js"
+
+/**
+ * Get the path to the CDK app file.
+ * When running from lib/, use the sibling cdk-app.js.
+ * When running from src/, fall back to the sibling cdk-app.ts.
+ */
+const getCdkAppPath = (): string => {
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = path.dirname(__filename)
+  // Check for compiled version in same directory (lib/cli/)
+  const jsPath = path.join(__dirname, "..", "cdk-app.js")
+  if (fs.existsSync(jsPath)) {
+    return jsPath
+  }
+  // Fall back to TypeScript source for local development (src/cli/)
+  return path.join(__dirname, "..", "cdk-app.ts")
+}
 
 /**
  * Discovered Lambda function info.
@@ -196,10 +214,8 @@ const runBootstrap = (options: {
   Effect.gen(function* () {
     yield* Effect.logInfo("Running bootstrap stack deployment...")
 
-    // Resolve the CDK app path relative to this module
-    const __filename = fileURLToPath(import.meta.url)
-    const __dirname = path.dirname(__filename)
-    const cdkAppPath = path.resolve(__dirname, "..", "cdk-app.js")
+    // Resolve the CDK app path (handles both compiled and source)
+    const cdkAppPath = getCdkAppPath()
 
     const args = [
       "cdk",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -30,7 +30,7 @@ export const BOOTSTRAP_STACK_NAME = "CdkLocalLambdaBootstrapStack"
  * Current version of the bootstrap stack.
  * Increment this when making breaking changes to the bootstrap infrastructure.
  */
-export const BOOTSTRAP_VERSION = "2"
+export const BOOTSTRAP_VERSION = "3"
 
 /**
  * Environment variable names used by the bridge handler

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -28,7 +28,9 @@
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": false,
     "noPropertyAccessFromIndexSignature": false,
-    "exactOptionalPropertyTypes": false
+    "exactOptionalPropertyTypes": false,
+    "rootDir": ".",
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
## Summary

Fixes the "Cannot find module 'index'" error when invoking Lambda functions with Node.js 24 runtime.

### Changes

- **fix(bootstrap)**: Switch bridge bundling from CJS to ESM (.mjs) to fix Bun bundling bug where exports were ordered before function definitions, causing empty module.exports
- **feat(cli)**: Add bootstrap version checking to `cll bootstrap` command - now skips deployment when deployed version >= required version
- **chore**: Bump bootstrap version from 2 to 3 to force redeployment with new bridge bundle

### Problem

The Bun bundler with `--format=cjs` produced output where `module.exports = ...` appeared at line 3980, but the `async function handler` was defined at line 4345. This caused the Lambda runtime to fail with "Cannot find module 'index'".

### Solution

Use Bun with `--format=esm` and `.mjs` extension instead. ESM properly exports the handler function regardless of definition order.

### Testing

- Verified `index.mjs` loads correctly in Node.js 24
- Verified bootstrap command skips when version 3 is already deployed
- Full build and test suite passes