### PR TITLE
docs: document Node.js 24 requirement and print version on CLI startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This project provides similar live Lambda development capabilities to [SST v2's 
 
 SST v2 requires adopting SST's stack conventions and constructs. With cdk-local-lambda, you keep your existing CDK code as-is—just add the bootstrap import and apply the aspect.
 
+## Prerequisites
+
+- **Node.js 24** or later
+
 ## Installation
 
 ```bash

--- a/src/cli/commands/local.ts
+++ b/src/cli/commands/local.ts
@@ -1661,7 +1661,9 @@ export const localCommand = Command.make(
   }) => {
     const logLevel = debug ? LogLevel.Debug : LogLevel.Info
     return Effect.gen(function* () {
-      yield* Effect.logInfo("[Local] Starting local Lambda development...")
+      yield* Effect.logInfo(
+        `[Local] Starting local Lambda development... (Node.js ${process.version})`,
+      )
 
       const profileValue = profile._tag === "Some" ? profile.value : undefined
       const regionValue = region._tag === "Some" ? region.value : undefined


### PR DESCRIPTION
## Summary

- Add a "Prerequisites" section to README.md documenting the Node.js 24 requirement
- Print the Node.js version (`process.version`) in the CLI startup log message for the `local` command