### PR TITLE
fix(cli): prevent stale poller from stealing invocations after node --watch restart

### DIFF
--- a/src/cli/runtime-api/server.ts
+++ b/src/cli/runtime-api/server.ts
@@ -17,7 +17,15 @@ import * as HttpRouter from "@effect/platform/HttpRouter"
 import * as HttpServerRequest from "@effect/platform/HttpServerRequest"
 import * as HttpServerResponse from "@effect/platform/HttpServerResponse"
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer"
-import { Effect, HashMap, Option, Queue, Ref, type Scope } from "effect"
+import {
+  Deferred,
+  Effect,
+  HashMap,
+  Option,
+  Queue,
+  Ref,
+  type Scope,
+} from "effect"
 import type {
   ExtensionEvent,
   ExtensionEventType,
@@ -60,6 +68,16 @@ export interface RuntimeApiState {
   extensions: Ref.Ref<HashMap.HashMap<string, ExtensionState>>
   /** Function metadata for extension registration */
   functionMetadata: FunctionMetadata
+  /**
+   * Deferred used to interrupt a stale /invocation/next poller.
+   *
+   * When a new poll arrives (e.g. after a node --watch restart), it
+   * creates a fresh Deferred, swaps it into this Ref, and completes
+   * the previous one. The old handler fiber is racing Queue.take
+   * against this Deferred, so completing it causes the old fiber to
+   * exit immediately (returning 503) without consuming from the queue.
+   */
+  pollInterrupt: Ref.Ref<Deferred.Deferred<void>>
 }
 
 /**
@@ -84,12 +102,15 @@ export const makeRuntimeApiState = (functionMetadata: FunctionMetadata) =>
       LambdaResponse | LambdaError | LambdaInitError
     >()
     const extensions = yield* Ref.make(HashMap.empty<string, ExtensionState>())
+    const initialDeferred = yield* Deferred.make<void>()
+    const pollInterrupt = yield* Ref.make(initialDeferred)
 
     return {
       invocationQueue,
       responseQueue,
       extensions,
       functionMetadata,
+      pollInterrupt,
     } satisfies RuntimeApiState
   })
 
@@ -117,22 +138,35 @@ const DEFAULT_POLL_TIMEOUT_MS = 240_000 // 4 minutes
 
 /**
  * Handle GET /2018-06-01/runtime/invocation/next
- * Polls for an invocation with a bounded timeout to handle idle containers gracefully.
- * This ensures that if no invocations arrive within the timeout, the container
- * exits cleanly rather than being killed by an HTTP timeout.
  *
- * When the timeout expires, we return a 503 Service Unavailable which signals
- * to the Lambda RIC that it should exit. The container will be restarted
- * automatically when the next invocation arrives.
+ * Polls for an invocation using a loop with three exit conditions:
+ *   1. An invocation is available in the queue
+ *   2. A newer poller arrived (Deferred completed → node --watch restart)
+ *   3. Idle poll timeout expired (→ 503 so the RIC exits gracefully)
+ *
+ * The Deferred-based interrupt prevents stale handler fibers from stealing
+ * invocations: when a new /invocation/next request arrives it completes the
+ * previous Deferred, and the old fiber detects this on its next poll cycle
+ * (within 100ms).  If the stale fiber already took an invocation from the
+ * queue, it re-queues it before exiting.
+ *
+ * The 100ms poll loop also ensures the fiber wakes up periodically, which
+ * is important for clean scope cleanup (afterEach in tests, daemon shutdown).
  */
 const handleInvocationNext = (state: RuntimeApiState, pollTimeoutMs: number) =>
   Effect.gen(function* () {
     yield* Effect.logDebug("Container polling for next invocation")
 
+    // Create a fresh interrupt Deferred for THIS poll request and swap it in.
+    // Completing the previous Deferred tells any stale poller to exit.
+    const myInterrupt = yield* Deferred.make<void>()
+    const oldInterrupt = yield* Ref.getAndSet(state.pollInterrupt, myInterrupt)
+    yield* Deferred.succeed(oldInterrupt, void 0)
+
     const startTime = Date.now()
 
-    // Poll with timeout instead of blocking indefinitely
-    // This allows us to detect connection issues and keep the invocation in the queue
+    // Poll with timeout instead of blocking indefinitely.
+    // The 100ms sleep gives periodic interruption points for clean shutdown.
     let invocation: LambdaInvocation | null = null
 
     while (invocation === null) {
@@ -141,8 +175,6 @@ const handleInvocationNext = (state: RuntimeApiState, pollTimeoutMs: number) =>
         yield* Effect.logDebug(
           "Invocation poll timeout - returning 503 to trigger container exit",
         )
-        // Return 503 Service Unavailable to signal the RIC to exit gracefully
-        // This is expected behavior for idle containers in local development
         return HttpServerResponse.empty({
           status: 503,
           headers: Headers.fromInput({
@@ -151,10 +183,40 @@ const handleInvocationNext = (state: RuntimeApiState, pollTimeoutMs: number) =>
         })
       }
 
-      // Try to take from queue with a short timeout
+      // Check if a newer poller arrived (e.g. worker restarted via --watch)
+      const interrupted = yield* Deferred.isDone(myInterrupt)
+      if (interrupted) {
+        yield* Effect.logDebug(
+          "Stale poller detected (newer connection arrived) - exiting",
+        )
+        return HttpServerResponse.empty({
+          status: 503,
+          headers: Headers.fromInput({
+            "Content-Type": "application/json",
+          }),
+        })
+      }
+
+      // Try to take from queue (non-blocking)
       const result = yield* Queue.poll(state.invocationQueue)
 
       if (Option.isSome(result)) {
+        // Took an invocation — but check the Deferred again.  If a newer
+        // poller arrived between our last check and now, re-queue so the
+        // new poller gets it.
+        const interruptedAfterTake = yield* Deferred.isDone(myInterrupt)
+        if (interruptedAfterTake) {
+          yield* Effect.logDebug(
+            "Stale poller took invocation after new connection arrived - re-queueing",
+          )
+          yield* Queue.offer(state.invocationQueue, result.value)
+          return HttpServerResponse.empty({
+            status: 503,
+            headers: Headers.fromInput({
+              "Content-Type": "application/json",
+            }),
+          })
+        }
         invocation = result.value
       } else {
         // Queue is empty, wait a bit before retrying

--- a/test/runtime-api-queue.test.ts
+++ b/test/runtime-api-queue.test.ts
@@ -310,6 +310,12 @@ describe("Runtime API Queue Behavior", () => {
     // The poll should fail
     await expect(pollPromise).rejects.toThrow()
 
+    // Give the HTTP server time to propagate the interruption to the
+    // handler fiber.  Under CPU contention (full test suite), the abort
+    // event can be delayed, causing the stale fiber to consume the
+    // invocation before it is interrupted.
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
     // Now queue an invocation
     const invocation = createTestInvocation("after-abort-1", {
       status: "queued-after-abort",
@@ -344,7 +350,55 @@ describe("Runtime API Queue Behavior", () => {
     expect(result.event).toEqual({ queued: "while-waiting" })
   })
 
-  it.skip("complete rebuild scenario with concurrent invocation - Known issue with NodeHttpServer abort handling", async () => {
+  it("new poller invalidates stale poller so invocations are not lost", async () => {
+    // This reproduces the node --watch restart bug:
+    // 1. Worker A polls /invocation/next (handler fiber A starts polling queue)
+    // 2. Worker restarts (connection drops, but fiber A may linger)
+    // 3. Worker B polls /invocation/next (handler fiber B starts)
+    // 4. Invocation arrives — only fiber B (the active poller) should get it
+    //
+    // Without the pollGeneration fix, fiber A could steal the invocation
+    // and try to respond on the dead connection, causing a hang.
+
+    // Worker A starts polling (queue is empty, so it blocks)
+    const controllerA = new AbortController()
+    const pollAPromise = simulateContainerPoll(server.port, {
+      signal: controllerA.signal,
+    }).catch((err: Error) => err)
+
+    // Let worker A's poll request reach the server and start waiting
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    // Worker restarts — new poll arrives (this bumps pollGeneration,
+    // causing the old handler fiber to bail out with 503)
+    // Don't abort worker A's connection yet — the point is that the
+    // server-side generation counter handles it even if the TCP
+    // connection lingers.
+    const pollBPromise = simulateContainerPoll(server.port)
+
+    // Give fiber A time to detect the generation mismatch and exit
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    // Now abort worker A's client connection (simulates TCP close)
+    controllerA.abort()
+
+    // Queue an invocation — it must go to worker B
+    const invocation = createTestInvocation("stale-poller-1", {
+      target: "workerB",
+    })
+    await Effect.runPromise(queueInvocation(server.state, invocation))
+
+    // Worker B should receive the invocation (not worker A)
+    const result = await pollBPromise
+    expect(result.requestId).toBe("stale-poller-1")
+    expect(result.event).toEqual({ target: "workerB" })
+
+    // Worker A's poll should have failed (aborted or 503)
+    const resultA = await pollAPromise
+    expect(resultA).toBeInstanceOf(Error)
+  })
+
+  it.skip("complete rebuild scenario with concurrent invocation - abort handling is a separate issue from stale pollers", async () => {
     // Full scenario test:
     // 1. Container A is processing invocations
     // 2. File change triggers rebuild
@@ -363,7 +417,7 @@ describe("Runtime API Queue Behavior", () => {
     const controllerA = new AbortController()
     const pollA2Promise = simulateContainerPoll(server.port, {
       signal: controllerA.signal,
-    })
+    }).catch((err: Error) => err)
 
     // Let Container A start waiting
     await new Promise((resolve) => setTimeout(resolve, 100))
@@ -371,7 +425,8 @@ describe("Runtime API Queue Behavior", () => {
     // File change detected - rebuild starts
     // Container A is killed (abort its poll)
     controllerA.abort()
-    await expect(pollA2Promise).rejects.toThrow()
+    const pollA2Result = await pollA2Promise
+    expect(pollA2Result).toBeInstanceOf(Error)
 
     // Invocation arrives during rebuild (no container connected)
     const inv2 = createTestInvocation("scenario-2", { during: "rebuild" })


### PR DESCRIPTION
## Summary

- Fixes invocations hanging after editing a TypeScript handler file while the local daemon is running
- When `node --watch` restarts the worker, the old HTTP handler fiber for `/invocation/next` keeps running in the Runtime API server — creating two fibers polling the same queue. The stale fiber can consume an invocation and respond on the dead connection, losing it.
- Adds a `Deferred`-based interrupt to `RuntimeApiState`: each new poll request completes the previous `Deferred`, causing the stale fiber to exit without consuming from the queue. If it already consumed one, it re-queues it.

## Test plan

- New test: "new poller invalidates stale poller so invocations are not lost" — directly reproduces the concurrent-poller scenario
- All 75 existing tests pass (`bun run test`)