### PR TITLE
fix!: suppress readiness check noise and improve Docker rebuild lifecycle

### DIFF
--- a/examples/complete/functions/echo/Dockerfile
+++ b/examples/complete/functions/echo/Dockerfile
@@ -16,5 +16,7 @@ EXPOSE 8080
 
 # Lambda Web Adapter expects the server to listen on PORT
 ENV PORT=8080
+# Use a dedicated readiness check path so health checks don't hit the handler
+ENV READINESS_CHECK_PATH=/healthz
 
 CMD ["bun", "handler.ts"]

--- a/examples/complete/functions/echo/handler.ts
+++ b/examples/complete/functions/echo/handler.ts
@@ -17,6 +17,12 @@ const PORT = Number(process.env.PORT) || 8080
 const server = Bun.serve({
   port: PORT,
   async fetch(request: Request): Promise<Response> {
+    // Readiness check endpoint for Lambda Web Adapter
+    const url = new URL(request.url)
+    if (url.pathname === "/healthz") {
+      return new Response("OK", { status: 200 })
+    }
+
     // Lambda Web Adapter sends the event as POST body to the root path
     // and includes Lambda context in headers
     const requestId =

--- a/src/cli/cdk-app.ts
+++ b/src/cli/cdk-app.ts
@@ -31,8 +31,10 @@ async function loadBootstrapStack() {
     "bootstrap-stack.js",
   )
   if (fs.existsSync(libPath)) {
-    // @ts-expect-error - Path exists at runtime after compilation
-    return import("../../lib/bootstrap-stack/bootstrap-stack.js")
+    // Use a variable so TypeScript cannot statically resolve the import
+    // (avoids TS5055: would overwrite input file on incremental builds)
+    const modulePath = libPath
+    return import(modulePath)
   }
 
   // Fall back to source version (src/bootstrap-stack/) using direct path resolution

--- a/src/cli/commands/local.ts
+++ b/src/cli/commands/local.ts
@@ -1147,6 +1147,8 @@ const ensureContainerStarted = (
 
 /**
  * Rebuild a Docker container after file changes.
+ * The new image is built first while the old container keeps serving requests.
+ * Once the image is ready, the old container is stopped and replaced.
  * Invocations arriving during rebuild will be queued and picked up by the new container.
  */
 const rebuildDockerContainer = (
@@ -1168,26 +1170,7 @@ const rebuildDockerContainer = (
     // Mark as rebuilding - invocations will still queue but we log it
     container.isRebuilding = true
 
-    yield* Effect.logDebug(`[Local] Rebuilding container for ${functionId}...`)
-
     const docker = yield* Docker
-
-    // Stop the existing container using Docker service
-    const containerId = container.containerName
-    yield* Effect.logInfo(
-      `[Local] Stopping container with name prefix: ${containerId}`,
-    )
-
-    const stopCount = yield* docker.stop(containerId).pipe(
-      Effect.scoped,
-      Effect.catchAll((error) =>
-        Effect.gen(function* () {
-          yield* Effect.logInfo(`Note: Container stop had issue: ${error}`)
-          return 0
-        }),
-      ),
-    )
-    yield* Effect.logDebug(`[Local] Stopped ${stopCount} container(s)`)
 
     // Resolve the context path
     const fn = container.fn
@@ -1198,7 +1181,9 @@ const rebuildDockerContainer = (
     // Determine platform from architecture
     const platform = fn.architecture === "arm64" ? "linux/arm64" : "linux/amd64"
 
-    // Rebuild the Docker image
+    // Build the new image first while the old container keeps serving
+    yield* Effect.logInfo(`[Local] Rebuilding container for ${functionId}...`)
+
     yield* docker
       .build({
         contextPath,
@@ -1216,15 +1201,29 @@ const rebuildDockerContainer = (
       imageConfig.cmd,
     )
 
-    // Restart the container by triggering container startup
-    // The existing fiber will have exited when we stopped the container
-    // We need to start a new one
+    // Image is ready - now stop the old container and start the new one
+    const containerId = container.containerName
+    yield* Effect.logInfo(`[Local] Replacing container for ${functionId}...`)
+
+    // Use fast timeout (1s) since the new image is ready - no need for graceful shutdown
+    const stopCount = yield* docker.stop(containerId, 1).pipe(
+      Effect.scoped,
+      Effect.catchAll((error) =>
+        Effect.gen(function* () {
+          yield* Effect.logInfo(`Note: Container stop had issue: ${error}`)
+          return 0
+        }),
+      ),
+    )
+    yield* Effect.logDebug(`[Local] Stopped ${stopCount} container(s)`)
+
+    // Start the replacement container
     const dockerRuntime = yield* docker.getRuntimeInfo()
     const runtimeApiHost = dockerRuntime.isDockerDesktop
       ? "host.docker.internal"
       : "runtime.api"
 
-    yield* Effect.logInfo(
+    yield* Effect.logDebug(
       `[Local] New container will connect to Runtime API at ${runtimeApiHost}:${container.port}`,
     )
 
@@ -1278,7 +1277,9 @@ const rebuildDockerContainer = (
     yield* Effect.sleep("2 seconds")
 
     container.isRebuilding = false
-    yield* Effect.logDebug(`[Local] Container rebuilt for ${functionId}`)
+    yield* Effect.logInfo(
+      `[Local] Container replaced for ${functionId} - new code is live`,
+    )
   }).pipe(Effect.provide(DockerLive))
 
 /**


### PR DESCRIPTION
## Summary

- **Suppress Lambda Web Adapter readiness check noise**: The adapter's GET `/` health check was hitting the echo handler and producing confusing output that looked like replayed invocations. Configured `READINESS_CHECK_PATH=/healthz` with a dedicated silent endpoint.
- **Improve Docker rebuild lifecycle**: Build the new image while the old container keeps serving, then swap with a fast 1-second stop timeout. Log messages now accurately reflect the state: rebuilding → replacing → new code is live.
- **Fix TS5055 incremental build error**: Made the bootstrap-stack dynamic import non-literal so TypeScript cannot resolve the output `.d.ts` as an input file on second+ builds.

## BREAKING CHANGE

Docker rebuild now builds the new image before stopping the old container, changing the container lifecycle semantics.