### PR TITLE
fix: add backoff retries for AppSync publishes

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -108,6 +108,10 @@
       "type": "runtime"
     },
     {
+      "name": "exponential-backoff",
+      "type": "runtime"
+    },
+    {
       "name": "ws",
       "type": "runtime"
     }

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -260,13 +260,13 @@
       },
       "steps": [
         {
-          "exec": "bunx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@biomejs/biome,@effect/language-service,@types/aws-lambda,@types/ws,aws-cdk,husky,projen,ts-node,tsx,typescript,@aws-crypto/sha256-js,@aws-sdk/client-lambda,@aws-sdk/client-s3,@aws-sdk/client-ssm,@aws-sdk/credential-provider-node,@aws-sdk/protocol-http,@aws-sdk/signature-v4,@effect/cli,@effect/platform,@effect/platform-node,aws-cdk-lib,chokidar,effect,ws"
+          "exec": "bunx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@biomejs/biome,@effect/language-service,@types/aws-lambda,@types/ws,aws-cdk,husky,projen,ts-node,tsx,typescript,@aws-crypto/sha256-js,@aws-sdk/client-lambda,@aws-sdk/client-s3,@aws-sdk/client-ssm,@aws-sdk/credential-provider-node,@aws-sdk/protocol-http,@aws-sdk/signature-v4,@effect/cli,@effect/platform,@effect/platform-node,aws-cdk-lib,chokidar,effect,exponential-backoff,ws"
         },
         {
           "exec": "bun install"
         },
         {
-          "exec": "bun update @biomejs/biome @effect/language-service @types/aws-lambda @types/node @types/ws aws-cdk commit-and-tag-version constructs husky projen ts-node tsx typescript @aws-crypto/sha256-js @aws-sdk/client-lambda @aws-sdk/client-s3 @aws-sdk/client-ssm @aws-sdk/credential-provider-node @aws-sdk/protocol-http @aws-sdk/signature-v4 @effect/cli @effect/platform @effect/platform-node aws-cdk-lib chokidar effect ws"
+          "exec": "bun update @biomejs/biome @effect/language-service @types/aws-lambda @types/node @types/ws aws-cdk commit-and-tag-version constructs husky projen ts-node tsx typescript @aws-crypto/sha256-js @aws-sdk/client-lambda @aws-sdk/client-s3 @aws-sdk/client-ssm @aws-sdk/credential-provider-node @aws-sdk/protocol-http @aws-sdk/signature-v4 @effect/cli @effect/platform @effect/platform-node aws-cdk-lib chokidar effect exponential-backoff ws"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -92,6 +92,7 @@ const project = new typescript.TypeScriptProject({
     "@aws-sdk/client-lambda",
     "ws",
     "chokidar",
+    "exponential-backoff",
   ],
   devDeps: [
     "@effect/language-service",

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "aws-cdk-lib": "^2.236.0",
         "chokidar": "^5.0.0",
         "effect": "^3.19.15",
+        "exponential-backoff": "^3.1.3",
         "ws": "^8.19.0",
       },
       "devDependencies": {
@@ -571,6 +572,8 @@
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "execa": ["execa@1.0.0", "", { "dependencies": { "cross-spawn": "^6.0.0", "get-stream": "^4.0.0", "is-stream": "^1.1.0", "npm-run-path": "^2.0.0", "p-finally": "^1.0.0", "signal-exit": "^3.0.0", "strip-eof": "^1.0.0" } }, "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA=="],
+
+    "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
     "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "aws-cdk-lib": "^2.236.0",
     "chokidar": "^5.0.0",
     "effect": "^3.19.15",
+    "exponential-backoff": "^3.1.3",
     "ws": "^8.19.0"
   },
   "keywords": [

--- a/src/cli/appsync/client.ts
+++ b/src/cli/appsync/client.ts
@@ -9,9 +9,29 @@ import { Sha256 } from "@aws-crypto/sha256-js"
 import { defaultProvider } from "@aws-sdk/credential-provider-node"
 import { HttpRequest } from "@aws-sdk/protocol-http"
 import { SignatureV4 } from "@aws-sdk/signature-v4"
-import { Effect, Stream } from "effect"
+import { Effect, Schedule, Stream } from "effect"
 import WebSocket from "ws"
 import type { InvocationMessage, ResponseMessage } from "../../shared/types.js"
+
+const PUBLISH_MAX_ATTEMPTS = 4
+
+class PublishError extends Error {
+  readonly retryable: boolean
+
+  constructor(
+    message: string,
+    options: {
+      retryable: boolean
+    },
+  ) {
+    super(message)
+    this.name = "PublishError"
+    this.retryable = options.retryable
+  }
+}
+
+const isRetryableStatusCode = (statusCode: number): boolean =>
+  statusCode === 429 || statusCode >= 500
 
 /**
  * Configuration for the Effect AppSync client.
@@ -168,29 +188,64 @@ export const makeAppSyncClient = (config: AppSyncClientConfig) => {
         body,
       })
 
-      const signedRequest = yield* signRequest(request)
-
       const publishUrl = `${url.protocol}//${url.hostname}${path}`
-      const response = yield* Effect.tryPromise({
-        try: async () =>
-          fetch(publishUrl, {
-            method: "POST",
-            headers: signedRequest.headers as Record<string, string>,
-            body,
-          }),
-        catch: (error) =>
-          new Error(`Failed to publish event: ${String(error)}`),
-      })
 
-      if (!response.ok) {
-        const text = yield* Effect.tryPromise({
-          try: () => response.text(),
-          catch: () => new Error("Failed to read response"),
+      let attempts = 0
+
+      yield* Effect.gen(function* () {
+        attempts += 1
+
+        // Sign on each attempt so SigV4 date/signature remain fresh
+        const signedRequest = yield* signRequest(request)
+
+        const response = yield* Effect.tryPromise({
+          try: async () =>
+            fetch(publishUrl, {
+              method: "POST",
+              headers: signedRequest.headers as Record<string, string>,
+              body,
+            }),
+          catch: (error) =>
+            new PublishError(`Failed to publish event: ${String(error)}`, {
+              retryable: true,
+            }),
         })
-        yield* Effect.fail(
-          new Error(`Failed to publish event: ${response.status} ${text}`),
-        )
-      }
+
+        if (!response.ok) {
+          const text = yield* Effect.tryPromise({
+            try: () => response.text(),
+            catch: () => new Error("Failed to read response"),
+          })
+          return yield* Effect.fail(
+            new PublishError(
+              `Failed to publish event: ${response.status} ${text}`,
+              {
+                retryable: isRetryableStatusCode(response.status),
+              },
+            ),
+          )
+        }
+      }).pipe(
+        Effect.retry({
+          times: PUBLISH_MAX_ATTEMPTS - 1,
+          schedule: Schedule.exponential("100 millis").pipe(Schedule.jittered),
+          while: (error) => {
+            if (error instanceof PublishError && error.retryable) {
+              return Effect.logDebug(
+                `[Local] Retrying AppSync publish: ${error.message}`,
+              ).pipe(Effect.as(true))
+            }
+            return false
+          },
+        }),
+        Effect.catchAll((error) =>
+          Effect.fail(
+            new Error(
+              `Failed to publish event after ${attempts} attempt(s): ${error.message}`,
+            ),
+          ),
+        ),
+      )
 
       yield* Effect.logDebug(`Published to ${channel}`)
     })

--- a/src/functions/bridge/appsync-client.ts
+++ b/src/functions/bridge/appsync-client.ts
@@ -10,7 +10,30 @@ import { Sha256 } from "@aws-crypto/sha256-js"
 import { defaultProvider } from "@aws-sdk/credential-provider-node"
 import { HttpRequest } from "@aws-sdk/protocol-http"
 import { SignatureV4 } from "@aws-sdk/signature-v4"
+import { backOff } from "exponential-backoff"
 import WebSocket from "ws"
+
+const PUBLISH_MAX_ATTEMPTS = 4
+const PUBLISH_RETRY_STARTING_DELAY_MS = 100
+const PUBLISH_RETRY_MAX_DELAY_MS = 2_000
+
+class PublishError extends Error {
+  readonly retryable: boolean
+
+  constructor(
+    message: string,
+    options: {
+      retryable: boolean
+    },
+  ) {
+    super(message)
+    this.name = "PublishError"
+    this.retryable = options.retryable
+  }
+}
+
+const isRetryableStatusCode = (statusCode: number): boolean =>
+  statusCode === 429 || statusCode >= 500
 
 export interface AppSyncEventsClientConfig {
   httpEndpoint: string
@@ -116,7 +139,8 @@ export class AppSyncEventsClient {
       body,
     })
 
-    // Sign the request
+    // Make the HTTP request - use the correct endpoint with /event path
+    const publishUrl = `${url.protocol}//${url.hostname}${path}`
     const signer = new SignatureV4({
       credentials: defaultProvider(),
       region: this.region,
@@ -124,19 +148,64 @@ export class AppSyncEventsClient {
       sha256: Sha256,
     })
 
-    const signedRequest = await signer.sign(request)
+    let attempts = 0
 
-    // Make the HTTP request - use the correct endpoint with /event path
-    const publishUrl = `${url.protocol}//${url.hostname}${path}`
-    const response = await fetch(publishUrl, {
-      method: "POST",
-      headers: signedRequest.headers as Record<string, string>,
-      body,
-    })
+    try {
+      await backOff(
+        async () => {
+          attempts += 1
 
-    if (!response.ok) {
-      const text = await response.text()
-      throw new Error(`Failed to publish event: ${response.status} ${text}`)
+          // Sign on each attempt so SigV4 date/signature remain fresh
+          const signedRequest = await signer.sign(request)
+
+          const response = await fetch(publishUrl, {
+            method: "POST",
+            headers: signedRequest.headers as Record<string, string>,
+            body,
+          })
+
+          if (!response.ok) {
+            const text = await response.text()
+            throw new PublishError(
+              `Failed to publish event: ${response.status} ${text}`,
+              {
+                retryable: isRetryableStatusCode(response.status),
+              },
+            )
+          }
+        },
+        {
+          numOfAttempts: PUBLISH_MAX_ATTEMPTS,
+          startingDelay: PUBLISH_RETRY_STARTING_DELAY_MS,
+          maxDelay: PUBLISH_RETRY_MAX_DELAY_MS,
+          timeMultiple: 2,
+          jitter: "full",
+          retry: (error: unknown) => {
+            if (error instanceof PublishError) {
+              if (error.retryable) {
+                console.warn(`[Bridge] Retrying publish: ${error.message}`)
+              }
+              return error.retryable
+            }
+            if (
+              error instanceof TypeError ||
+              (error instanceof Error && error.name === "AbortError")
+            ) {
+              console.warn(
+                `[Bridge] Retrying publish after transport error: ${error}`,
+              )
+              return true
+            }
+            return false
+          },
+        },
+      )
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error)
+      throw new Error(
+        `Failed to publish event after ${attempts} attempt(s): ${errorMessage}`,
+      )
     }
   }
 

--- a/test/runtime-api-queue.test.ts
+++ b/test/runtime-api-queue.test.ts
@@ -317,7 +317,7 @@ describe("Runtime API Queue Behavior", () => {
     // Start polling (this will block since queue is empty)
     const pollPromise = simulateContainerPoll(server.port, {
       signal: controller.signal,
-    })
+    }).catch((error: Error) => error)
 
     // Let the poll start waiting
     await new Promise((resolve) => setTimeout(resolve, 200))
@@ -326,7 +326,8 @@ describe("Runtime API Queue Behavior", () => {
     controller.abort()
 
     // The poll should fail
-    await expect(pollPromise).rejects.toThrow()
+    const pollResult = await pollPromise
+    expect(pollResult).toBeInstanceOf(Error)
 
     // Give the HTTP server time to propagate the interruption to the
     // handler fiber.  Under CPU contention (full test suite), the abort

--- a/test/runtime-api-queue.test.ts
+++ b/test/runtime-api-queue.test.ts
@@ -59,12 +59,30 @@ function createTestInvocation(
  */
 async function simulateContainerPoll(
   port: number,
-  options: { signal?: AbortSignal } = {},
+  options: { signal?: AbortSignal; timeoutMs?: number } = {},
 ): Promise<{ event: unknown; requestId: string }> {
-  const response = await fetch(
-    `http://localhost:${port}/2018-06-01/runtime/invocation/next`,
-    { signal: options.signal },
-  )
+  const timeoutMs = options.timeoutMs ?? 10_000
+  const controller = new AbortController()
+
+  const abortFromCaller = () => {
+    controller.abort()
+  }
+  options.signal?.addEventListener("abort", abortFromCaller, { once: true })
+
+  const timeoutId = setTimeout(() => {
+    controller.abort()
+  }, timeoutMs)
+
+  let response: Response
+  try {
+    response = await fetch(
+      `http://localhost:${port}/2018-06-01/runtime/invocation/next`,
+      { signal: controller.signal },
+    )
+  } finally {
+    clearTimeout(timeoutId)
+    options.signal?.removeEventListener("abort", abortFromCaller)
+  }
 
   if (!response.ok) {
     throw new Error(`Poll failed with status ${response.status}`)


### PR DESCRIPTION
## Summary
- add bounded exponential-backoff retries to bridge AppSync HTTP publishes, retrying only transient transport failures and 429/5xx responses
- add equivalent retry policy to daemon AppSync publishes using Effect `Schedule.exponential(...).pipe(Schedule.jittered)` and retryable error classification
- re-sign SigV4 requests on every retry attempt and include attempt count in terminal publish errors for easier diagnosis

## Verification
- bun run compile
- bun run test