### PR TITLE
fix(cli): preload tsx for local node workers

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -48,10 +48,6 @@
       "type": "build"
     },
     {
-      "name": "tsx",
-      "type": "build"
-    },
-    {
       "name": "typescript",
       "type": "build"
     },
@@ -109,6 +105,10 @@
     },
     {
       "name": "exponential-backoff",
+      "type": "runtime"
+    },
+    {
+      "name": "tsx",
       "type": "runtime"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -260,13 +260,13 @@
       },
       "steps": [
         {
-          "exec": "bunx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@biomejs/biome,@effect/language-service,@types/aws-lambda,@types/ws,aws-cdk,husky,projen,ts-node,tsx,typescript,@aws-crypto/sha256-js,@aws-sdk/client-lambda,@aws-sdk/client-s3,@aws-sdk/client-ssm,@aws-sdk/credential-provider-node,@aws-sdk/protocol-http,@aws-sdk/signature-v4,@effect/cli,@effect/platform,@effect/platform-node,aws-cdk-lib,chokidar,effect,exponential-backoff,ws"
+          "exec": "bunx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@biomejs/biome,@effect/language-service,@types/aws-lambda,@types/ws,aws-cdk,husky,projen,ts-node,typescript,@aws-crypto/sha256-js,@aws-sdk/client-lambda,@aws-sdk/client-s3,@aws-sdk/client-ssm,@aws-sdk/credential-provider-node,@aws-sdk/protocol-http,@aws-sdk/signature-v4,@effect/cli,@effect/platform,@effect/platform-node,aws-cdk-lib,chokidar,effect,exponential-backoff,tsx,ws"
         },
         {
           "exec": "bun install"
         },
         {
-          "exec": "bun update @biomejs/biome @effect/language-service @types/aws-lambda @types/node @types/ws aws-cdk commit-and-tag-version constructs husky projen ts-node tsx typescript @aws-crypto/sha256-js @aws-sdk/client-lambda @aws-sdk/client-s3 @aws-sdk/client-ssm @aws-sdk/credential-provider-node @aws-sdk/protocol-http @aws-sdk/signature-v4 @effect/cli @effect/platform @effect/platform-node aws-cdk-lib chokidar effect exponential-backoff ws"
+          "exec": "bun update @biomejs/biome @effect/language-service @types/aws-lambda @types/node @types/ws aws-cdk commit-and-tag-version constructs husky projen ts-node typescript @aws-crypto/sha256-js @aws-sdk/client-lambda @aws-sdk/client-s3 @aws-sdk/client-ssm @aws-sdk/credential-provider-node @aws-sdk/protocol-http @aws-sdk/signature-v4 @effect/cli @effect/platform @effect/platform-node aws-cdk-lib chokidar effect exponential-backoff tsx ws"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -93,6 +93,7 @@ const project = new typescript.TypeScriptProject({
     "ws",
     "chokidar",
     "exponential-backoff",
+    "tsx",
   ],
   devDeps: [
     "@effect/language-service",
@@ -101,7 +102,6 @@ const project = new typescript.TypeScriptProject({
     "@types/node@24",
     "@types/ws",
     "husky",
-    "tsx", // Use tsx instead of ts-node (ts-node fails with ESM + Node 18.19+)
   ],
 })
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "chokidar": "^5.0.0",
         "effect": "^3.21.0",
         "exponential-backoff": "^3.1.3",
+        "tsx": "^4.21.0",
         "ws": "^8.20.0",
       },
       "devDependencies": {
@@ -33,7 +34,6 @@
         "husky": "^9.1.7",
         "projen": "^0.99.23",
         "ts-node": "^10.9.2",
-        "tsx": "^4.21.0",
         "typescript": "^5.9.3",
       },
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "husky": "^9.1.7",
     "projen": "^0.99.23",
     "ts-node": "^10.9.2",
-    "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
   "dependencies": {
@@ -66,6 +65,7 @@
     "chokidar": "^5.0.0",
     "effect": "^3.21.0",
     "exponential-backoff": "^3.1.3",
+    "tsx": "^4.21.0",
     "ws": "^8.20.0"
   },
   "keywords": [

--- a/src/cli/commands/local.ts
+++ b/src/cli/commands/local.ts
@@ -13,6 +13,7 @@
 
 import { type ChildProcess, spawn } from "node:child_process"
 import * as fs from "node:fs"
+import { createRequire } from "node:module"
 import * as path from "node:path"
 import { fileURLToPath } from "node:url"
 import {
@@ -617,7 +618,7 @@ const processContainerResponses = (
 
 /**
  * Start a Node.js worker process for a function.
- * Spawns Bun to run the runtime wrapper with the handler path.
+ * Spawns Node.js with tsx preloaded to run the runtime wrapper.
  * The worker continuously polls our Runtime API for invocations.
  */
 const startNodejsWorker = (
@@ -645,6 +646,9 @@ const startNodejsWorker = (
       "nodejs-runtime.js",
     )
 
+    const require = createRequire(import.meta.url)
+    const tsxLoaderPath = require.resolve("tsx")
+
     // Use current Node.js executable for pure env isolation (no PATH dependency)
     const nodePath = process.execPath
 
@@ -666,14 +670,17 @@ const startNodejsWorker = (
     )
     yield* Effect.logDebug(`[Local] Handler: ${fn.localHandler}`)
 
-    // Spawn Node.js with --watch to automatically restart when handler files change
-    // This enables hot-reload without needing to restart the daemon
-    // Use current Node.js executable for pure env isolation (no PATH dependency)
-    const workerProcess = spawn(nodePath, ["--watch", runtimeWrapperPath], {
-      cwd: projectRoot,
-      env: workerEnv,
-      stdio: ["ignore", "pipe", "pipe"],
-    })
+    // Preload tsx so direct source imports work for TypeScript workspaces.
+    // Keep using the current Node.js executable to avoid PATH dependencies.
+    const workerProcess = spawn(
+      nodePath,
+      ["--import", tsxLoaderPath, "--watch", runtimeWrapperPath],
+      {
+        cwd: projectRoot,
+        env: workerEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    )
 
     // Pattern to parse Lambda log format: TIMESTAMP\tREQUEST_ID\tLEVEL\tMESSAGE
     // Lambda uses tabs between fields. Captures: [1] = request ID, [2] = level + message


### PR DESCRIPTION
## Summary
- preload `tsx` for local Node.js workers so direct TypeScript workspace handlers can be imported during live execution
- move `tsx` to runtime dependencies because the CLI now resolves and loads it at runtime
- keep the existing Node worker model and `--watch` behavior while avoiding plain-Node handler load failures

## Testing
- `npm run build`
- `npx tsc --build && bun test ./test/*.test.ts ./test/shared/*.test.ts`